### PR TITLE
Improve clarity of WPA-Enterprise page

### DIFF
--- a/wpa-enterprise.html
+++ b/wpa-enterprise.html
@@ -1,80 +1,1738 @@
-<!doctype html><html lang="en-US" dir="ltr" data-nojs><head><title>WPA-Enterprise</title><meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no"><meta http-equiv="Content-Type" content="text/html; charset=utf-8"/><meta name="generator" content="Zoho Sites 2.0, https://zoho.com/sites"/><link rel="icon" href="/favicon.png"/><link rel="canonical" href="https://www.ironwifi.com/wpa-enterprise"/><meta name="twitter:card" content="summary"><meta name="twitter:url" content="https://www.ironwifi.com/wpa-enterprise"><meta name="twitter:title" content="WPA-Enterprise"><meta property="og:type" content="website"><meta property="og:url" content="https://www.ironwifi.com/wpa-enterprise"><meta property="og:title" content="WPA-Enterprise"><meta name="keywords" content="WPA-Enterprise"/><link href="https://www.ironwifi.com/wpa-enterprise" rel="alternate" hreflang="x-default"><link href="/css/zsite-core.css" rel="preload" type="text/css" as="style"><link href="/css/zsite-core.css" rel="stylesheet" type="text/css"><link rel="preconnect" href="//img.zohostatic.com"><link rel="preconnect" href="//static.zohocdn.com"><link href="/template/28ab700d22dd48dfac75bc403d523144/stylesheets/style.css" rel="preload" type="text/css" as="style"><link href="/template/28ab700d22dd48dfac75bc403d523144/stylesheets/style.css" rel="stylesheet" type="text/css"><link href="/template/28ab700d22dd48dfac75bc403d523144/stylesheets/sub-style.css" rel="preload" type="text/css" as="style"><link href="/template/28ab700d22dd48dfac75bc403d523144/stylesheets/sub-style.css" rel="stylesheet" type="text/css"><link rel="preload" type="text/css" href="//webfonts.zoho.com/css?family=Montserrat:400,700/Poppins:400,600,700,800&amp;display=swap" as="style"><link rel="stylesheet" type="text/css" href="//webfonts.zoho.com/css?family=Montserrat:400,700/Poppins:400,600,700,800&amp;display=swap"><link href="/zs-customcss.css" rel="preload" type="text/css" as="style"><link href="/zs-customcss.css" rel="stylesheet" type="text/css"><script>document.documentElement.removeAttribute('data-nojs');</script><script>window.zs_content_format="0";window.zs_resource_url ="/wpa-enterprise";window.isDefaultLogo = "false";window.zs_site_resource_id = "1867570000000002010";</script><script>window.is_portal_site="false";</script><script src="/zs-lang_en_US.js" defer></script><script src="/js/zsite-core.js" defer></script><script src="/template/28ab700d22dd48dfac75bc403d523144/js/header.js" defer></script><script src="/template/28ab700d22dd48dfac75bc403d523144/js/eventhandler.js" defer></script><script src="/template/28ab700d22dd48dfac75bc403d523144/js/megamenu.js" defer></script><script src="/template/28ab700d22dd48dfac75bc403d523144/js/language-list.js" defer></script><script>window.zs_data_center="USA";</script><script>window.stand_alone_path="";</script><script>window.zs_rendering_mode="live";</script><script>window.is_social_share_enabled="true";</script><script src="https://zsites.nimbuspop.com/IDC/js/browser_compatibility.js" defer></script><script>window.zs_resource_id = "1867570000000019645";window.zs_resource_type = "1";window.zs_site_resource_path = "";window.zs_resource_full_path ="/wpa-enterprise";window.zs_site_resource_id = "1867570000000002010";window.zs_resource_contentstate = "3";window.zs_page_reviewer =  null;</script><script type="application/ld+json" id="schemagenerator">{"@context":"http:\/\/schema.org\/","@type":"Organization","name":"IronWiFi","url":"https:\/\/www.ironwifi.com","logo":"http:\/\/www.ironwifi.com\/.Diseño sin título -4-.png_t.jpg","address":{"addressCountry":"United States","streetAddress":"100 E Pine St","@type":"PostalAddress","postalCode":"32801","addressLocality":"Ste 110","addressRegion":"Orlando"},"contactPoint":{"@type":"ContactPoint","telephone":"+18009636221","email":"sales@ironwifi.com"},"sameAs":["https:\/\/www.linkedin.com\/company\/ironwifi\/"]}</script><!-- Google Tag Manager --><script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-NQTXMN');</script><!-- End Google Tag Manager --></head><body data-zs-home="true" data-zs-subsite="" data-zs-display-mode="default"><!-- Google Tag Manager (noscript) --><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NQTXMN" height="0" width="0" style="display:none;visibility:hidden;"></iframe></noscript><!-- End Google Tag Manager (noscript) --><a href="#thememaincontent" class="theme-skip-to-needed-content">Skip to main content</a><div data-headercontainer="zptheme-data-headercontainer" class="zpheader-style-01 theme-mobile-header-fixed theme-pages-full-stretch theme-mobile-header-style-01" data-headercontainer="zptheme-data-headercontainer" data-zs-mobile-headerstyle="01" class="zpheader-style-01 theme-mobile-header-fixed theme-pages-full-stretch theme-mobile-header-style-01"><div class="theme-header-topbar theme-hide-res-topbar " data-dark-part-applied="false" data-theme-topbar="zptheme-topbar"><div class="zpcontainer"></div>
-</div><div data-megamenu-content-container class="theme-header " data-header="zptheme-data-header-transparent" data-dark-part-applied="false" data-banner-base-header="theme-banner-base-header"><div class="zpcontainer"><div data-zs-branding class="theme-branding-info " data-theme-branding-info="zptheme-branding-info"><div data-zs-logo-container class="theme-logo-parent "><a href="/" title="Logo"><picture><img data-zs-logo src="/ironwifi.png" alt="IronWiFi" style="height:89px;width:248.9px;"/></picture></a></div>
-</div><div class="theme-navigation-and-icons"><div class="theme-menu-area" data-zp-nonresponsive-container="mymenu1"><div class="theme-menu " data-nav-menu-icon-width=15 data-nav-menu-icon-height=15 data-sub-menu-icon-height=15 data-sub-menu-icon-width=15 data-mega-menu-icon-width=15 data-mega-menu-icon-height=15 data-non-res-menu="zptheme-menu-non-res" data-zp-theme-menu="id: mymenu1 ;active: theme-menu-selected; maxitem:5;position: theme-sub-menu-position-change; orientation: horizontal; submenu: theme-sub-menu; moretext: More; nonresponsive-icon-el: theme-non-responsive-menu; responsive-icon-el: theme-responsive-menu; burger-close-icon: theme-close-icon; animate-open: theme-toggle-animate; animate-close: theme-toggle-animate-end;open-icon: theme-submenu-down-arrow; close-icon: theme-submenu-up-arrow; root-icon: theme-submenu-down-arrow; subtree-icon: theme-submenu-right-arrow;" role="navigation"><ul data-zs-menu-container><li><a href="/solutions" target="_self" data-theme-accessible-submenu aria-haspopup="true" aria-label="Solutions menu has sub menu" aria-expanded="false"><span class="theme-menu-content "><span class="theme-menu-name" data-theme-menu-name="Solutions">Solutions</span></span><span class="theme-sub-li-menu theme-non-responsive-menu theme-submenu-down-arrow"></span><span class="theme-sub-li-menu theme-responsive-menu theme-submenu-down-arrow"></span></a><ul class="theme-sub-menu" data-zs-submenu-container style="display:none;"><li><a href="/coworking" target="_self"><span class="theme-menu-content "><span class="theme-menu-name" data-theme-menu-name="Coworking">Coworking</span></span></a></li><li><a href="/education" target="_self"><span class="theme-menu-content "><span class="theme-menu-name" data-theme-menu-name="Education">Education</span></span></a></li><li><a href="/enterprise" target="_self"><span class="theme-menu-content "><span class="theme-menu-name" data-theme-menu-name="Enterprise">Enterprise</span></span></a></li><li><a href="/events" target="_self"><span class="theme-menu-content "><span class="theme-menu-name" data-theme-menu-name="Events">Events</span></span></a></li><li><a href="/hospitality" target="_self"><span class="theme-menu-content "><span class="theme-menu-name" data-theme-menu-name="Hospitality">Hospitality</span></span></a></li><li><a href="/retail" target="_self"><span class="theme-menu-content "><span class="theme-menu-name" data-theme-menu-name="Retail">Retail</span></span></a></li><li><a href="/small-business" target="_self"><span class="theme-menu-content "><span class="theme-menu-name" data-theme-menu-name="Small Business">Small Business</span></span></a></li></ul></li><li><a href="/products" target="_self" data-theme-accessible-submenu aria-haspopup="true" aria-label="Products menu has sub menu" aria-expanded="false"><span class="theme-menu-content "><span class="theme-menu-name" data-theme-menu-name="Products">Products</span></span><span class="theme-sub-li-menu theme-non-responsive-menu theme-submenu-down-arrow"></span><span class="theme-sub-li-menu theme-responsive-menu theme-submenu-down-arrow"></span></a><ul class="theme-sub-menu" data-zs-submenu-container style="display:none;"><li><a href="/captive-portal" target="_self" data-theme-accessible-submenu aria-haspopup="true" aria-label="Captive Portal menu has sub menu" aria-expanded="false"><span class="theme-menu-content "><span class="theme-menu-name" data-theme-menu-name="Captive Portal">Captive Portal</span></span><span class="theme-sub-li-menu theme-non-responsive-menu theme-submenu-right-arrow"></span><span class="theme-sub-li-menu theme-responsive-menu theme-submenu-down-arrow"></span></a><ul class="theme-sub-menu" data-zs-submenu-container style="display:none;"><li><a href="/captive-portal-demos" target="_self"><span class="theme-menu-content "><span class="theme-menu-name" data-theme-menu-name="Captive Portal Demos">Captive Portal Demos</span></span></a></li></ul></li><li><a href="/wpa-enterprise" target="_self"><span class="theme-menu-content "><span class="theme-menu-name" data-theme-menu-name="WPA-Enterprise">WPA-Enterprise</span></span></a></li><li><a href="/scep" target="_self"><span class="theme-menu-content "><span class="theme-menu-name" data-theme-menu-name="SCEP">SCEP</span></span></a></li><li><a href="/passpoint" target="_self"><span class="theme-menu-content "><span class="theme-menu-name" data-theme-menu-name="Passpoint">Passpoint</span></span></a></li><li><a href="https://osu.ironwifi.com/" target="_blank"><span class="theme-menu-content "><span class="theme-menu-name" data-theme-menu-name="OpenRoaming OSU">OpenRoaming OSU</span></span></a></li><li><a href="/openroaming-radius" target="_self"><span class="theme-menu-content "><span class="theme-menu-name" data-theme-menu-name="OpenRoaming RADIUS">OpenRoaming RADIUS</span></span></a></li></ul></li><li><a href="/pricing" target="_self"><span class="theme-menu-content "><span class="theme-menu-name" data-theme-menu-name="Pricing">Pricing</span></span></a></li><li><a href="/Resellers" target="_self"><span class="theme-menu-content "><span class="theme-menu-name" data-theme-menu-name="Resellers">Resellers</span></span></a></li><li data-zp-more-menu="mymenu1"><a href="javascript:;" target="_self" data-theme-accessible-submenu aria-haspopup="true" aria-label="More menu has sub menu" aria-expanded="false"><span class="theme-menu-content "><span class="theme-menu-name" data-theme-menu-name="More">More</span></span><span class="theme-sub-li-menu theme-non-responsive-menu theme-submenu-down-arrow"></span><span class="theme-sub-li-menu theme-responsive-menu theme-submenu-down-arrow"></span></a><ul class="theme-sub-menu" data-zs-submenu-container style="display:none;"><li><a href="/support" target="_self" data-theme-accessible-submenu aria-haspopup="true" aria-label="Support menu has sub menu" aria-expanded="false"><span class="theme-menu-content "><span class="theme-menu-name" data-theme-menu-name="Support">Support</span></span><span class="theme-sub-li-menu theme-non-responsive-menu theme-submenu-right-arrow"></span><span class="theme-sub-li-menu theme-responsive-menu theme-submenu-down-arrow"></span></a><ul class="theme-sub-menu" data-zs-submenu-container style="display:none;"><li><a href="https://help.ironwifi.com/portal/en/home" target="_blank"><span class="theme-menu-content "><span class="theme-menu-name" data-theme-menu-name="Help Center">Help Center</span></span></a></li><li><a href="https://meetings.ironwifi.com/#/ironwifi" target="_blank"><span class="theme-menu-content "><span class="theme-menu-name" data-theme-menu-name="Schedule a Call">Schedule a Call</span></span></a></li><li><a href="/list-of-supported-vendors" target="_self"><span class="theme-menu-content "><span class="theme-menu-name" data-theme-menu-name="Compatible HW">Compatible HW</span></span></a></li><li><a href="/integrations" target="_self"><span class="theme-menu-content "><span class="theme-menu-name" data-theme-menu-name="Integrations">Integrations</span></span></a></li><li><a href="https://api.ironwifi.com/" target="_blank"><span class="theme-menu-content "><span class="theme-menu-name" data-theme-menu-name="API  Reference">API Reference</span></span></a></li><li><a href="/dpa" target="_self"><span class="theme-menu-content "><span class="theme-menu-name" data-theme-menu-name="DPA">DPA</span></span></a></li><li><a href="https://meetings.ironwifi.com/#/sales" target="_blank"><span class="theme-menu-content "><span class="theme-menu-name" data-theme-menu-name="Contact Sales">Contact Sales</span></span></a></li></ul></li><li><a href="/about-us" target="_self"><span class="theme-menu-content "><span class="theme-menu-name" data-theme-menu-name="About">About</span></span></a></li><li class="menu-highlight-primary"><a href="https://console.ironwifi.io/api/login" target="_blank"><span class="theme-menu-content "><span class="theme-menu-name" data-theme-menu-name="Sign In">Sign In</span></span></a></li></ul></li></ul><div data-zp-submenu-icon="mymenu1" style="display:none;"><span class="theme-sub-li-menu theme-non-responsive-menu"></span><span class="theme-sub-li-menu theme-responsive-menu theme-submenu-down-arrow"></span></div>
-</div></div></div></div><div data-zs-responsive-menu-area class="theme-responsive-menu-area theme-navigation-and-icons zpcontainer"><div class="theme-responsive-menu-container" data-zp-burger-clickable-area="mymenu1"><span class="theme-burger-icon" data-zp-theme-burger-icon="mymenu1"></span></div>
-<div class="theme-responsive-menu theme-menu-area" data-zp-responsive-container="mymenu1"></div>
-</div></div></div><div data-theme-content-container="theme-content-container" class="theme-content-area theme-pages-full-stretch"><div class="theme-content-container"><div class="theme-content-area-inner"><div class="zpcontent-container page-container "><div data-element-id="elm_aSNWWOAsT_S5Y4TcvT3pqw" data-element-type="section" class="zpsection zpdefault-section zpdefault-section-bg zscustom-section-bizxpert-06 "><style type="text/css"> [data-element-id="elm_aSNWWOAsT_S5Y4TcvT3pqw"].zpsection{ border-radius:1px; padding-block-end:1px; } </style><div class="zpcontainer-fluid zpcontainer"><div data-element-id="elm_NRzjliYwQMG6ofWc540yEg" data-element-type="row" class="zprow zprow-container zs-bx-mt-n200 zpalign-items-flex-start zpjustify-content-flex-start zpdefault-section zpdefault-section-bg " data-equal-column=""><style type="text/css"> [data-element-id="elm_NRzjliYwQMG6ofWc540yEg"].zprow{ border-radius:1px; } </style><div data-element-id="elm_q1eq_fReSyKqyORYoiukNg" data-element-type="column" class="zpelem-col zpcol-12 zpcol-md-4 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg "><style type="text/css"> [data-element-id="elm_q1eq_fReSyKqyORYoiukNg"].zpelem-col{ border-radius:1px; } </style></div>
-<div data-element-id="elm_ZKjBYILSTNCzLH-nwVH6gg" data-element-type="column" class="zpelem-col zpcol-12 zpcol-md-4 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg "><style type="text/css"> [data-element-id="elm_ZKjBYILSTNCzLH-nwVH6gg"].zpelem-col{ border-radius:1px; } </style></div>
-<div data-element-id="elm_kxCpc5dTSU6phBdeAZXrhA" data-element-type="column" class="zpelem-col zpcol-12 zpcol-md-4 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg "><style type="text/css"> [data-element-id="elm_kxCpc5dTSU6phBdeAZXrhA"].zpelem-col{ border-radius:1px; } </style></div>
-</div><div data-element-id="elm_Fhi3IEW_Q7qegYCXa_FCrw" data-element-type="row" class="zprow zprow-container zpalign-items-flex-start zpjustify-content-flex-start zpdefault-section zpdefault-section-bg " data-equal-column=""><style type="text/css"> [data-element-id="elm_Fhi3IEW_Q7qegYCXa_FCrw"].zprow{ border-radius:1px; } </style><div data-element-id="elm_VwwEA0N3TZ-GxcCqQC0EXg" data-element-type="column" class="zpelem-col zpcol-12 zpcol-md-12 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg "><style type="text/css"> [data-element-id="elm_VwwEA0N3TZ-GxcCqQC0EXg"].zpelem-col{ border-radius:1px; } </style><div data-element-id="elm_-jSsrFacTkiZlUxF8VWJJg" data-element-type="spacer" class="zpelement zpelem-spacer "><style> div[data-element-id="elm_-jSsrFacTkiZlUxF8VWJJg"] div.zpspacer { height:68px; } @media (max-width: 768px) { div[data-element-id="elm_-jSsrFacTkiZlUxF8VWJJg"] div.zpspacer { height:calc(68px / 3); } } </style><div class="zpspacer " data-height="68"></div>
-</div><div data-element-id="elm_N8IofSD7jXMj-Ne22-Q_EA" data-element-type="spacer" class="zpelement zpelem-spacer "><style> div[data-element-id="elm_N8IofSD7jXMj-Ne22-Q_EA"] div.zpspacer { height:52px; } @media (max-width: 768px) { div[data-element-id="elm_N8IofSD7jXMj-Ne22-Q_EA"] div.zpspacer { height:calc(52px / 3); } } </style><div class="zpspacer " data-height="52"></div>
-</div><div data-element-id="elm_8aFqZ6nYxOmu-zG9ZnFXcg" data-element-type="heading" class="zpelement zpelem-heading "><style></style><h2
- class="zpheading zpheading-style-none zpheading-align-left zpheading-align-mobile-left zpheading-align-tablet-left " data-editor="true"><span><span>Enforce Enterprise-Level Security on Your Wireless Networks</span></span></h2></div>
-<div data-element-id="elm_5a4L-21moL0Tfw-6F1z0mQ" data-element-type="text" class="zpelement zpelem-text "><style></style><div class="zptext zptext-align-left zptext-align-mobile-left zptext-align-tablet-left " data-editor="true"><p></p><div><p>IronWiFi allows you to encrypt your data and protect it from unauthorized access with Advanced Encryption Standard (AES) and Temporal Key Integrity Protocol (TKIP). Users can also be authenticated easily with EAP (Extensible Authentication Protocol), which integrates seamlessly with a RADIUS server for centralized user authentication and management.</p><p><br/></p><p>Keep reading below for more information.</p></div><p></p></div>
-</div><div data-element-id="elm_XXbkq7MPSwOq4b4s8i5Wiw" data-element-type="row" class="zprow zprow-container zpalign-items-center zpjustify-content-flex-start zpdefault-section zpdefault-section-bg " data-equal-column="false"><style type="text/css"> [data-element-id="elm_XXbkq7MPSwOq4b4s8i5Wiw"].zprow{ border-radius:1px; margin-block-start:-72px; } </style><div data-element-id="elm_bSfv1IuPTRC6qxsSKRQ_Rw" data-element-type="column" class="zpelem-col zpcol-12 zpcol-md-6 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg "><style type="text/css"> [data-element-id="elm_bSfv1IuPTRC6qxsSKRQ_Rw"].zpelem-col{ border-radius:1px; } </style><div data-element-id="elm_9kIzGfnQYzOhFW3JYLkfnA" data-element-type="zforms" class="zpelement zpelem-zforms "><style type="text/css"> [data-element-id="elm_9kIzGfnQYzOhFW3JYLkfnA"].zpelem-zforms{ margin-block-start:97px; } </style><div class="zpiframe-container zpiframe-align-left"><iframe class="zpiframe " src="https://forms.zohopublic.com/ironwifi/form/Contactusandwewouldtohelpyouwiththeonboardingproce/formperma/oBRxwS_wIf7fiwMwDVYi_FBiVWRK-n6Jy0ifU26Xrvk" form_id="1690063000000094167" width="100%" height="500" align="left" frameBorder="0"></iframe></div>
-</div></div><div data-element-id="elm_LAiY7GOEQNWWZs4Mly1qgw" data-element-type="column" class="zpelem-col zpcol-12 zpcol-md-6 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg "><style type="text/css"> [data-element-id="elm_LAiY7GOEQNWWZs4Mly1qgw"].zpelem-col{ border-radius:1px; } </style><div data-element-id="elm_HWc0a_77UEsgozD3JKxcbg" data-element-type="image" class="zpelement zpelem-image "><style> @media (min-width: 992px) { [data-element-id="elm_HWc0a_77UEsgozD3JKxcbg"] .zpimage-container figure img { width: 637px !important ; height: 425px !important ; } } [data-element-id="elm_HWc0a_77UEsgozD3JKxcbg"].zpelem-image { margin-block-start:101px; } </style><div data-caption-color="" data-size-tablet="" data-size-mobile="" data-align="center" data-tablet-image-separate="false" data-mobile-image-separate="false" class="zpimage-container zpimage-align-center zpimage-tablet-align-center zpimage-mobile-align-center zpimage-size-custom zpimage-tablet-fallback-fit zpimage-mobile-fallback-fit hb-lightbox " data-lightbox-options="
+<!DOCTYPE html>
+<html data-nojs="" dir="ltr" lang="en-US">
+ <head>
+  <title>
+   WPA-Enterprise
+  </title>
+  <meta content="width=device-width, initial-scale=1.0, shrink-to-fit=no" name="viewport"/>
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
+   <meta content="Zoho Sites 2.0, https://zoho.com/sites" name="generator"/>
+   <link href="/favicon.png" rel="icon"/>
+   <link href="https://www.ironwifi.com/wpa-enterprise" rel="canonical"/>
+   <meta content="summary" name="twitter:card"/>
+   <meta content="https://www.ironwifi.com/wpa-enterprise" name="twitter:url"/>
+   <meta content="WPA-Enterprise" name="twitter:title"/>
+   <meta content="website" property="og:type"/>
+   <meta content="https://www.ironwifi.com/wpa-enterprise" property="og:url"/>
+   <meta content="WPA-Enterprise" property="og:title"/>
+   <meta content="WPA-Enterprise" name="keywords">
+    <link href="https://www.ironwifi.com/wpa-enterprise" hreflang="x-default" rel="alternate"/>
+    <link as="style" href="/css/zsite-core.css" rel="preload" type="text/css"/>
+    <link href="/css/zsite-core.css" rel="stylesheet" type="text/css"/>
+    <link href="//img.zohostatic.com" rel="preconnect"/>
+    <link href="//static.zohocdn.com" rel="preconnect"/>
+    <link as="style" href="/template/28ab700d22dd48dfac75bc403d523144/stylesheets/style.css" rel="preload" type="text/css"/>
+    <link href="/template/28ab700d22dd48dfac75bc403d523144/stylesheets/style.css" rel="stylesheet" type="text/css"/>
+    <link as="style" href="/template/28ab700d22dd48dfac75bc403d523144/stylesheets/sub-style.css" rel="preload" type="text/css"/>
+    <link href="/template/28ab700d22dd48dfac75bc403d523144/stylesheets/sub-style.css" rel="stylesheet" type="text/css"/>
+    <link as="style" href="//webfonts.zoho.com/css?family=Montserrat:400,700/Poppins:400,600,700,800&amp;display=swap" rel="preload" type="text/css"/>
+    <link href="//webfonts.zoho.com/css?family=Montserrat:400,700/Poppins:400,600,700,800&amp;display=swap" rel="stylesheet" type="text/css"/>
+    <link as="style" href="/zs-customcss.css" rel="preload" type="text/css"/>
+    <link href="/zs-customcss.css" rel="stylesheet" type="text/css"/>
+    <script>
+     document.documentElement.removeAttribute('data-nojs');
+    </script>
+    <script>
+     window.zs_content_format="0";window.zs_resource_url ="/wpa-enterprise";window.isDefaultLogo = "false";window.zs_site_resource_id = "1867570000000002010";
+    </script>
+    <script>
+     window.is_portal_site="false";
+    </script>
+    <script defer="" src="/zs-lang_en_US.js">
+    </script>
+    <script defer="" src="/js/zsite-core.js">
+    </script>
+    <script defer="" src="/template/28ab700d22dd48dfac75bc403d523144/js/header.js">
+    </script>
+    <script defer="" src="/template/28ab700d22dd48dfac75bc403d523144/js/eventhandler.js">
+    </script>
+    <script defer="" src="/template/28ab700d22dd48dfac75bc403d523144/js/megamenu.js">
+    </script>
+    <script defer="" src="/template/28ab700d22dd48dfac75bc403d523144/js/language-list.js">
+    </script>
+    <script>
+     window.zs_data_center="USA";
+    </script>
+    <script>
+     window.stand_alone_path="";
+    </script>
+    <script>
+     window.zs_rendering_mode="live";
+    </script>
+    <script>
+     window.is_social_share_enabled="true";
+    </script>
+    <script defer="" src="https://zsites.nimbuspop.com/IDC/js/browser_compatibility.js">
+    </script>
+    <script>
+     window.zs_resource_id = "1867570000000019645";window.zs_resource_type = "1";window.zs_site_resource_path = "";window.zs_resource_full_path ="/wpa-enterprise";window.zs_site_resource_id = "1867570000000002010";window.zs_resource_contentstate = "3";window.zs_page_reviewer =  null;
+    </script>
+    <script id="schemagenerator" type="application/ld+json">
+     {"@context":"http:\/\/schema.org\/","@type":"Organization","name":"IronWiFi","url":"https:\/\/www.ironwifi.com","logo":"http:\/\/www.ironwifi.com\/.Diseño sin título -4-.png_t.jpg","address":{"addressCountry":"United States","streetAddress":"100 E Pine St","@type":"PostalAddress","postalCode":"32801","addressLocality":"Ste 110","addressRegion":"Orlando"},"contactPoint":{"@type":"ContactPoint","telephone":"+18009636221","email":"sales@ironwifi.com"},"sameAs":["https:\/\/www.linkedin.com\/company\/ironwifi\/"]}
+    </script>
+    <!-- Google Tag Manager -->
+    <script>
+     (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-NQTXMN');
+    </script>
+    <!-- End Google Tag Manager -->
+   </meta>
+  </meta>
+ </head>
+ <body data-zs-display-mode="default" data-zs-home="true" data-zs-subsite="">
+  <!-- Google Tag Manager (noscript) -->
+  <noscript>
+   <iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-NQTXMN" style="display:none;visibility:hidden;" width="0">
+   </iframe>
+  </noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <a class="theme-skip-to-needed-content" href="#thememaincontent">
+   Skip to main content
+  </a>
+  <div class="zpheader-style-01 theme-mobile-header-fixed theme-pages-full-stretch theme-mobile-header-style-01" data-headercontainer="zptheme-data-headercontainer" data-zs-mobile-headerstyle="01">
+   <div class="theme-header-topbar theme-hide-res-topbar" data-dark-part-applied="false" data-theme-topbar="zptheme-topbar">
+    <div class="zpcontainer">
+    </div>
+   </div>
+   <div class="theme-header" data-banner-base-header="theme-banner-base-header" data-dark-part-applied="false" data-header="zptheme-data-header-transparent" data-megamenu-content-container="">
+    <div class="zpcontainer">
+     <div class="theme-branding-info" data-theme-branding-info="zptheme-branding-info" data-zs-branding="">
+      <div class="theme-logo-parent" data-zs-logo-container="">
+       <a href="/" title="Logo">
+        <picture>
+         <img alt="IronWiFi" data-zs-logo="" src="/ironwifi.png" style="height:89px;width:248.9px;"/>
+        </picture>
+       </a>
+      </div>
+     </div>
+     <div class="theme-navigation-and-icons">
+      <div class="theme-menu-area" data-zp-nonresponsive-container="mymenu1">
+       <div class="theme-menu" data-mega-menu-icon-height="15" data-mega-menu-icon-width="15" data-nav-menu-icon-height="15" data-nav-menu-icon-width="15" data-non-res-menu="zptheme-menu-non-res" data-sub-menu-icon-height="15" data-sub-menu-icon-width="15" data-zp-theme-menu="id: mymenu1 ;active: theme-menu-selected; maxitem:5;position: theme-sub-menu-position-change; orientation: horizontal; submenu: theme-sub-menu; moretext: More; nonresponsive-icon-el: theme-non-responsive-menu; responsive-icon-el: theme-responsive-menu; burger-close-icon: theme-close-icon; animate-open: theme-toggle-animate; animate-close: theme-toggle-animate-end;open-icon: theme-submenu-down-arrow; close-icon: theme-submenu-up-arrow; root-icon: theme-submenu-down-arrow; subtree-icon: theme-submenu-right-arrow;" role="navigation">
+        <ul data-zs-menu-container="">
+         <li>
+          <a aria-expanded="false" aria-haspopup="true" aria-label="Solutions menu has sub menu" data-theme-accessible-submenu="" href="/solutions" target="_self">
+           <span class="theme-menu-content">
+            <span class="theme-menu-name" data-theme-menu-name="Solutions">
+             Solutions
+            </span>
+           </span>
+           <span class="theme-sub-li-menu theme-non-responsive-menu theme-submenu-down-arrow">
+           </span>
+           <span class="theme-sub-li-menu theme-responsive-menu theme-submenu-down-arrow">
+           </span>
+          </a>
+          <ul class="theme-sub-menu" data-zs-submenu-container="" style="display:none;">
+           <li>
+            <a href="/coworking" target="_self">
+             <span class="theme-menu-content">
+              <span class="theme-menu-name" data-theme-menu-name="Coworking">
+               Coworking
+              </span>
+             </span>
+            </a>
+           </li>
+           <li>
+            <a href="/education" target="_self">
+             <span class="theme-menu-content">
+              <span class="theme-menu-name" data-theme-menu-name="Education">
+               Education
+              </span>
+             </span>
+            </a>
+           </li>
+           <li>
+            <a href="/enterprise" target="_self">
+             <span class="theme-menu-content">
+              <span class="theme-menu-name" data-theme-menu-name="Enterprise">
+               Enterprise
+              </span>
+             </span>
+            </a>
+           </li>
+           <li>
+            <a href="/events" target="_self">
+             <span class="theme-menu-content">
+              <span class="theme-menu-name" data-theme-menu-name="Events">
+               Events
+              </span>
+             </span>
+            </a>
+           </li>
+           <li>
+            <a href="/hospitality" target="_self">
+             <span class="theme-menu-content">
+              <span class="theme-menu-name" data-theme-menu-name="Hospitality">
+               Hospitality
+              </span>
+             </span>
+            </a>
+           </li>
+           <li>
+            <a href="/retail" target="_self">
+             <span class="theme-menu-content">
+              <span class="theme-menu-name" data-theme-menu-name="Retail">
+               Retail
+              </span>
+             </span>
+            </a>
+           </li>
+           <li>
+            <a href="/small-business" target="_self">
+             <span class="theme-menu-content">
+              <span class="theme-menu-name" data-theme-menu-name="Small Business">
+               Small Business
+              </span>
+             </span>
+            </a>
+           </li>
+          </ul>
+         </li>
+         <li>
+          <a aria-expanded="false" aria-haspopup="true" aria-label="Products menu has sub menu" data-theme-accessible-submenu="" href="/products" target="_self">
+           <span class="theme-menu-content">
+            <span class="theme-menu-name" data-theme-menu-name="Products">
+             Products
+            </span>
+           </span>
+           <span class="theme-sub-li-menu theme-non-responsive-menu theme-submenu-down-arrow">
+           </span>
+           <span class="theme-sub-li-menu theme-responsive-menu theme-submenu-down-arrow">
+           </span>
+          </a>
+          <ul class="theme-sub-menu" data-zs-submenu-container="" style="display:none;">
+           <li>
+            <a aria-expanded="false" aria-haspopup="true" aria-label="Captive Portal menu has sub menu" data-theme-accessible-submenu="" href="/captive-portal" target="_self">
+             <span class="theme-menu-content">
+              <span class="theme-menu-name" data-theme-menu-name="Captive Portal">
+               Captive Portal
+              </span>
+             </span>
+             <span class="theme-sub-li-menu theme-non-responsive-menu theme-submenu-right-arrow">
+             </span>
+             <span class="theme-sub-li-menu theme-responsive-menu theme-submenu-down-arrow">
+             </span>
+            </a>
+            <ul class="theme-sub-menu" data-zs-submenu-container="" style="display:none;">
+             <li>
+              <a href="/captive-portal-demos" target="_self">
+               <span class="theme-menu-content">
+                <span class="theme-menu-name" data-theme-menu-name="Captive Portal Demos">
+                 Captive Portal Demos
+                </span>
+               </span>
+              </a>
+             </li>
+            </ul>
+           </li>
+           <li>
+            <a href="/wpa-enterprise" target="_self">
+             <span class="theme-menu-content">
+              <span class="theme-menu-name" data-theme-menu-name="WPA-Enterprise">
+               WPA-Enterprise
+              </span>
+             </span>
+            </a>
+           </li>
+           <li>
+            <a href="/scep" target="_self">
+             <span class="theme-menu-content">
+              <span class="theme-menu-name" data-theme-menu-name="SCEP">
+               SCEP
+              </span>
+             </span>
+            </a>
+           </li>
+           <li>
+            <a href="/passpoint" target="_self">
+             <span class="theme-menu-content">
+              <span class="theme-menu-name" data-theme-menu-name="Passpoint">
+               Passpoint
+              </span>
+             </span>
+            </a>
+           </li>
+           <li>
+            <a href="https://osu.ironwifi.com/" target="_blank">
+             <span class="theme-menu-content">
+              <span class="theme-menu-name" data-theme-menu-name="OpenRoaming OSU">
+               OpenRoaming OSU
+              </span>
+             </span>
+            </a>
+           </li>
+           <li>
+            <a href="/openroaming-radius" target="_self">
+             <span class="theme-menu-content">
+              <span class="theme-menu-name" data-theme-menu-name="OpenRoaming RADIUS">
+               OpenRoaming RADIUS
+              </span>
+             </span>
+            </a>
+           </li>
+          </ul>
+         </li>
+         <li>
+          <a href="/pricing" target="_self">
+           <span class="theme-menu-content">
+            <span class="theme-menu-name" data-theme-menu-name="Pricing">
+             Pricing
+            </span>
+           </span>
+          </a>
+         </li>
+         <li>
+          <a href="/Resellers" target="_self">
+           <span class="theme-menu-content">
+            <span class="theme-menu-name" data-theme-menu-name="Resellers">
+             Resellers
+            </span>
+           </span>
+          </a>
+         </li>
+         <li data-zp-more-menu="mymenu1">
+          <a aria-expanded="false" aria-haspopup="true" aria-label="More menu has sub menu" data-theme-accessible-submenu="" href="javascript:;" target="_self">
+           <span class="theme-menu-content">
+            <span class="theme-menu-name" data-theme-menu-name="More">
+             More
+            </span>
+           </span>
+           <span class="theme-sub-li-menu theme-non-responsive-menu theme-submenu-down-arrow">
+           </span>
+           <span class="theme-sub-li-menu theme-responsive-menu theme-submenu-down-arrow">
+           </span>
+          </a>
+          <ul class="theme-sub-menu" data-zs-submenu-container="" style="display:none;">
+           <li>
+            <a aria-expanded="false" aria-haspopup="true" aria-label="Support menu has sub menu" data-theme-accessible-submenu="" href="/support" target="_self">
+             <span class="theme-menu-content">
+              <span class="theme-menu-name" data-theme-menu-name="Support">
+               Support
+              </span>
+             </span>
+             <span class="theme-sub-li-menu theme-non-responsive-menu theme-submenu-right-arrow">
+             </span>
+             <span class="theme-sub-li-menu theme-responsive-menu theme-submenu-down-arrow">
+             </span>
+            </a>
+            <ul class="theme-sub-menu" data-zs-submenu-container="" style="display:none;">
+             <li>
+              <a href="https://help.ironwifi.com/portal/en/home" target="_blank">
+               <span class="theme-menu-content">
+                <span class="theme-menu-name" data-theme-menu-name="Help Center">
+                 Help Center
+                </span>
+               </span>
+              </a>
+             </li>
+             <li>
+              <a href="https://meetings.ironwifi.com/#/ironwifi" target="_blank">
+               <span class="theme-menu-content">
+                <span class="theme-menu-name" data-theme-menu-name="Schedule a Call">
+                 Schedule a Call
+                </span>
+               </span>
+              </a>
+             </li>
+             <li>
+              <a href="/list-of-supported-vendors" target="_self">
+               <span class="theme-menu-content">
+                <span class="theme-menu-name" data-theme-menu-name="Compatible HW">
+                 Compatible HW
+                </span>
+               </span>
+              </a>
+             </li>
+             <li>
+              <a href="/integrations" target="_self">
+               <span class="theme-menu-content">
+                <span class="theme-menu-name" data-theme-menu-name="Integrations">
+                 Integrations
+                </span>
+               </span>
+              </a>
+             </li>
+             <li>
+              <a href="https://api.ironwifi.com/" target="_blank">
+               <span class="theme-menu-content">
+                <span class="theme-menu-name" data-theme-menu-name="API  Reference">
+                 API Reference
+                </span>
+               </span>
+              </a>
+             </li>
+             <li>
+              <a href="/dpa" target="_self">
+               <span class="theme-menu-content">
+                <span class="theme-menu-name" data-theme-menu-name="DPA">
+                 DPA
+                </span>
+               </span>
+              </a>
+             </li>
+             <li>
+              <a href="https://meetings.ironwifi.com/#/sales" target="_blank">
+               <span class="theme-menu-content">
+                <span class="theme-menu-name" data-theme-menu-name="Contact Sales">
+                 Contact Sales
+                </span>
+               </span>
+              </a>
+             </li>
+            </ul>
+           </li>
+           <li>
+            <a href="/about-us" target="_self">
+             <span class="theme-menu-content">
+              <span class="theme-menu-name" data-theme-menu-name="About">
+               About
+              </span>
+             </span>
+            </a>
+           </li>
+           <li class="menu-highlight-primary">
+            <a href="https://console.ironwifi.io/api/login" target="_blank">
+             <span class="theme-menu-content">
+              <span class="theme-menu-name" data-theme-menu-name="Sign In">
+               Sign In
+              </span>
+             </span>
+            </a>
+           </li>
+          </ul>
+         </li>
+        </ul>
+        <div data-zp-submenu-icon="mymenu1" style="display:none;">
+         <span class="theme-sub-li-menu theme-non-responsive-menu">
+         </span>
+         <span class="theme-sub-li-menu theme-responsive-menu theme-submenu-down-arrow">
+         </span>
+        </div>
+       </div>
+      </div>
+     </div>
+    </div>
+    <div class="theme-responsive-menu-area theme-navigation-and-icons zpcontainer" data-zs-responsive-menu-area="">
+     <div class="theme-responsive-menu-container" data-zp-burger-clickable-area="mymenu1">
+      <span class="theme-burger-icon" data-zp-theme-burger-icon="mymenu1">
+      </span>
+     </div>
+     <div class="theme-responsive-menu theme-menu-area" data-zp-responsive-container="mymenu1">
+     </div>
+    </div>
+   </div>
+  </div>
+  <div class="theme-content-area theme-pages-full-stretch" data-theme-content-container="theme-content-container">
+   <div class="theme-content-container">
+    <div class="theme-content-area-inner">
+     <div class="zpcontent-container page-container">
+      <div class="zpsection zpdefault-section zpdefault-section-bg zscustom-section-bizxpert-06" data-element-id="elm_aSNWWOAsT_S5Y4TcvT3pqw" data-element-type="section">
+       <style type="text/css">
+        [data-element-id="elm_aSNWWOAsT_S5Y4TcvT3pqw"].zpsection{ border-radius:1px; padding-block-end:1px; }
+       </style>
+       <div class="zpcontainer-fluid zpcontainer">
+        <div class="zprow zprow-container zs-bx-mt-n200 zpalign-items-flex-start zpjustify-content-flex-start zpdefault-section zpdefault-section-bg" data-element-id="elm_NRzjliYwQMG6ofWc540yEg" data-element-type="row" data-equal-column="">
+         <style type="text/css">
+          [data-element-id="elm_NRzjliYwQMG6ofWc540yEg"].zprow{ border-radius:1px; }
+         </style>
+         <div class="zpelem-col zpcol-12 zpcol-md-4 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg" data-element-id="elm_q1eq_fReSyKqyORYoiukNg" data-element-type="column">
+          <style type="text/css">
+           [data-element-id="elm_q1eq_fReSyKqyORYoiukNg"].zpelem-col{ border-radius:1px; }
+          </style>
+         </div>
+         <div class="zpelem-col zpcol-12 zpcol-md-4 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg" data-element-id="elm_ZKjBYILSTNCzLH-nwVH6gg" data-element-type="column">
+          <style type="text/css">
+           [data-element-id="elm_ZKjBYILSTNCzLH-nwVH6gg"].zpelem-col{ border-radius:1px; }
+          </style>
+         </div>
+         <div class="zpelem-col zpcol-12 zpcol-md-4 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg" data-element-id="elm_kxCpc5dTSU6phBdeAZXrhA" data-element-type="column">
+          <style type="text/css">
+           [data-element-id="elm_kxCpc5dTSU6phBdeAZXrhA"].zpelem-col{ border-radius:1px; }
+          </style>
+         </div>
+        </div>
+        <div class="zprow zprow-container zpalign-items-flex-start zpjustify-content-flex-start zpdefault-section zpdefault-section-bg" data-element-id="elm_Fhi3IEW_Q7qegYCXa_FCrw" data-element-type="row" data-equal-column="">
+         <style type="text/css">
+          [data-element-id="elm_Fhi3IEW_Q7qegYCXa_FCrw"].zprow{ border-radius:1px; }
+         </style>
+         <div class="zpelem-col zpcol-12 zpcol-md-12 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg" data-element-id="elm_VwwEA0N3TZ-GxcCqQC0EXg" data-element-type="column">
+          <style type="text/css">
+           [data-element-id="elm_VwwEA0N3TZ-GxcCqQC0EXg"].zpelem-col{ border-radius:1px; }
+          </style>
+          <div class="zpelement zpelem-spacer" data-element-id="elm_-jSsrFacTkiZlUxF8VWJJg" data-element-type="spacer">
+           <style>
+            div[data-element-id="elm_-jSsrFacTkiZlUxF8VWJJg"] div.zpspacer { height:68px; } @media (max-width: 768px) { div[data-element-id="elm_-jSsrFacTkiZlUxF8VWJJg"] div.zpspacer { height:calc(68px / 3); } }
+           </style>
+           <div class="zpspacer" data-height="68">
+           </div>
+          </div>
+          <div class="zpelement zpelem-spacer" data-element-id="elm_N8IofSD7jXMj-Ne22-Q_EA" data-element-type="spacer">
+           <style>
+            div[data-element-id="elm_N8IofSD7jXMj-Ne22-Q_EA"] div.zpspacer { height:52px; } @media (max-width: 768px) { div[data-element-id="elm_N8IofSD7jXMj-Ne22-Q_EA"] div.zpspacer { height:calc(52px / 3); } }
+           </style>
+           <div class="zpspacer" data-height="52">
+           </div>
+          </div>
+          <div class="zpelement zpelem-heading" data-element-id="elm_8aFqZ6nYxOmu-zG9ZnFXcg" data-element-type="heading">
+           <style>
+           </style>
+           <h2 class="zpheading zpheading-style-none zpheading-align-left zpheading-align-mobile-left zpheading-align-tablet-left" data-editor="true">
+            <span>
+             <span>
+              Enforce Enterprise-Level Security on Your Wireless Networks
+             </span>
+            </span>
+           </h2>
+          </div>
+          <div class="zpelement zpelem-text" data-element-id="elm_5a4L-21moL0Tfw-6F1z0mQ" data-element-type="text">
+           <style>
+           </style>
+           <div class="zptext zptext-align-left zptext-align-mobile-left zptext-align-tablet-left" data-editor="true">
+            <p>
+            </p>
+            <div>
+             <p>
+              IronWiFi allows you to encrypt your data and protect it from unauthorized access with Advanced Encryption Standard (AES) and Temporal Key Integrity Protocol (TKIP). Users can also be authenticated easily with EAP (Extensible Authentication Protocol), which integrates seamlessly with a RADIUS server for centralized user authentication and management.
+             </p>
+             <p>
+              <br/>
+             </p>
+             <p>
+              Keep reading below for more information.
+             </p>
+            </div>
+            <p>
+            </p>
+           </div>
+          </div>
+          <div class="zprow zprow-container zpalign-items-center zpjustify-content-flex-start zpdefault-section zpdefault-section-bg" data-element-id="elm_XXbkq7MPSwOq4b4s8i5Wiw" data-element-type="row" data-equal-column="false">
+           <style type="text/css">
+            [data-element-id="elm_XXbkq7MPSwOq4b4s8i5Wiw"].zprow{ border-radius:1px; margin-block-start:-72px; }
+           </style>
+           <div class="zpelem-col zpcol-12 zpcol-md-6 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg" data-element-id="elm_bSfv1IuPTRC6qxsSKRQ_Rw" data-element-type="column">
+            <style type="text/css">
+             [data-element-id="elm_bSfv1IuPTRC6qxsSKRQ_Rw"].zpelem-col{ border-radius:1px; }
+            </style>
+            <div class="zpelement zpelem-zforms" data-element-id="elm_9kIzGfnQYzOhFW3JYLkfnA" data-element-type="zforms">
+             <style type="text/css">
+              [data-element-id="elm_9kIzGfnQYzOhFW3JYLkfnA"].zpelem-zforms{ margin-block-start:97px; }
+             </style>
+             <div class="zpiframe-container zpiframe-align-left">
+              <iframe align="left" class="zpiframe" form_id="1690063000000094167" frameborder="0" height="500" src="https://forms.zohopublic.com/ironwifi/form/Contactusandwewouldtohelpyouwiththeonboardingproce/formperma/oBRxwS_wIf7fiwMwDVYi_FBiVWRK-n6Jy0ifU26Xrvk" width="100%">
+              </iframe>
+             </div>
+            </div>
+           </div>
+           <div class="zpelem-col zpcol-12 zpcol-md-6 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg" data-element-id="elm_LAiY7GOEQNWWZs4Mly1qgw" data-element-type="column">
+            <style type="text/css">
+             [data-element-id="elm_LAiY7GOEQNWWZs4Mly1qgw"].zpelem-col{ border-radius:1px; }
+            </style>
+            <div class="zpelement zpelem-image" data-element-id="elm_HWc0a_77UEsgozD3JKxcbg" data-element-type="image">
+             <style>
+              @media (min-width: 992px) { [data-element-id="elm_HWc0a_77UEsgozD3JKxcbg"] .zpimage-container figure img { width: 637px !important ; height: 425px !important ; } } [data-element-id="elm_HWc0a_77UEsgozD3JKxcbg"].zpelem-image { margin-block-start:101px; }
+             </style>
+             <div class="zpimage-container zpimage-align-center zpimage-tablet-align-center zpimage-mobile-align-center zpimage-size-custom zpimage-tablet-fallback-fit zpimage-mobile-fallback-fit hb-lightbox" data-align="center" data-caption-color="" data-lightbox-options="
                 type:fullscreen,
-                theme:dark"><figure role="none" class="zpimage-data-ref"><span class="zpimage-anchor" role="link" tabindex="0" aria-label="Open Lightbox" style="cursor:pointer;"><picture><img class="zpimage zpimage-style-none zpimage-space-none " src="/wap_1.png" size="custom" data-lightbox="true"/></picture></span></figure></div>
-</div></div></div><div data-element-id="elm_pZzxD-vVQjSb5KCLC2joUw" data-element-type="spacer" class="zpelement zpelem-spacer "><style> div[data-element-id="elm_pZzxD-vVQjSb5KCLC2joUw"] div.zpspacer { height:14px; } @media (max-width: 768px) { div[data-element-id="elm_pZzxD-vVQjSb5KCLC2joUw"] div.zpspacer { height:calc(14px / 3); } } </style><div class="zpspacer " data-height="14"></div>
-</div></div></div></div></div><div data-element-id="elm_ndh960jOKYM_Nbbo8C636Q" data-element-type="section" class="zpsection zpdefault-section zpdefault-section-bg "><style type="text/css"> [data-element-id="elm_ndh960jOKYM_Nbbo8C636Q"].zpsection{ padding-block-start:1px; padding-block-end:42px; } </style><div class="zpcontainer-fluid zpcontainer"><div data-element-id="elm_JX8xpX5lRDLPWQhkDrZZIw" data-element-type="row" class="zprow zprow-container zpalign-items-flex-start zpjustify-content-flex-start zpdefault-section zpdefault-section-bg " data-equal-column="false"><style type="text/css"></style><div data-element-id="elm_Ri0FlX6x2oAMUv7obbpDHw" data-element-type="column" class="zpelem-col zpcol-12 zpcol-md-12 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg "><style type="text/css"></style><div data-element-id="elm_DTUcSFsLnuCDLnH5rGg8Yw" data-element-type="heading" class="zpelement zpelem-heading "><style></style><h2
- class="zpheading zpheading-style-none zpheading-align-left zpheading-align-mobile-left zpheading-align-tablet-left " data-editor="true"><span style="font-size:24px;">Access a Robust and Secure Wireless Security Protocol</span></h2></div>
-<div data-element-id="elm_G8-7PscJ2yluVb4eJBuEEg" data-element-type="accordion" class="zpelement zpelem-accordion " data-tabs-inactive="true" data-icon-style="4"><style> [data-element-id="elm_G8-7PscJ2yluVb4eJBuEEg"] .zpaccordion-container.zpaccordion-style-01 .zpaccordion, [data-element-id="elm_G8-7PscJ2yluVb4eJBuEEg"] .zpaccordion-container.zpaccordion-style-01 .zpaccordion-content{ border-style:solid; border-color: !important; } [data-element-id="elm_G8-7PscJ2yluVb4eJBuEEg"] .zpaccordion-container.zpaccordion-style-01 .zpaccordion-content.zpaccordion-active-content:last-of-type{ border-block-end-width:1px !important; } [data-element-id="elm_G8-7PscJ2yluVb4eJBuEEg"] .zpaccordion-container.zpaccordion-style-01 .zpaccordion.zpaccordion-active + .zpaccordion-content{ border-block-start-color: transparent !important; } @media all and (min-width: 768px) and (max-width:991px){ [data-element-id="elm_G8-7PscJ2yluVb4eJBuEEg"] .zpaccordion-container.zpaccordion-style-01 .zpaccordion, [data-element-id="elm_G8-7PscJ2yluVb4eJBuEEg"] .zpaccordion-container.zpaccordion-style-01 .zpaccordion-content{ border-style:solid; border-color: !important; } [data-element-id="elm_G8-7PscJ2yluVb4eJBuEEg"] .zpaccordion-container.zpaccordion-style-01 .zpaccordion-content:last-of-type{ border-block-end-width:1px !important; } [data-element-id="elm_G8-7PscJ2yluVb4eJBuEEg"] .zpaccordion-container.zpaccordion-style-01 .zpaccordion.zpaccordion-active + .zpaccordion-content{ border-block-start-color: transparent !important; } } @media all and (max-width:767px){ [data-element-id="elm_G8-7PscJ2yluVb4eJBuEEg"] .zpaccordion-container.zpaccordion-style-01 .zpaccordion, [data-element-id="elm_G8-7PscJ2yluVb4eJBuEEg"] .zpaccordion-container.zpaccordion-style-01 .zpaccordion-content{ border-style:solid; border-color: !important; } [data-element-id="elm_G8-7PscJ2yluVb4eJBuEEg"] .zpaccordion-container.zpaccordion-style-01 .zpaccordion-content:last-of-type{ border-block-end-width:1px !important; } [data-element-id="elm_G8-7PscJ2yluVb4eJBuEEg"] .zpaccordion-container.zpaccordion-style-01 .zpaccordion.zpaccordion-active + .zpaccordion-content{ border-block-start-color: transparent !important; } } </style><div class="zpaccordion-container zpaccordion-style-01 zpaccordion-with-icon zpaccord-svg-icon-4 zpaccordion-icon-align-left "><div data-element-id="elm_MOkuup_yiil3ka_Gmfc2DA" data-element-type="accordionheader" class="zpelement zpaccordion " data-tab-name="What is WPA Enterprise Level Security?" data-content-id="elm_83IrP4v9xihlitbCBsvqYQ" style="margin-top:0;" tabindex="0" role="button" aria-label="What is WPA Enterprise Level Security?"><span class="zpaccordion-name">What is WPA Enterprise Level Security?</span><span class="zpaccordionicon zpaccord-icon-inactive"><svg aria-hidden="true" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" class="svg-icon-15px zpaccord-svg-icon-1"><path d="M98.9,184.7l1.8,2.1l136,156.5c4.6,5.3,11.5,8.6,19.2,8.6c7.7,0,14.6-3.4,19.2-8.6L411,187.1l2.3-2.6 c1.7-2.5,2.7-5.5,2.7-8.7c0-8.7-7.4-15.8-16.6-15.8v0H112.6v0c-9.2,0-16.6,7.1-16.6,15.8C96,179.1,97.1,182.2,98.9,184.7z"></path></svg><svg aria-hidden="true" viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg" class="svg-icon-15px zpaccord-svg-icon-2"><path d="M128,169.174c-1.637,0-3.276-0.625-4.525-1.875l-56.747-56.747c-2.5-2.499-2.5-6.552,0-9.05c2.497-2.5,6.553-2.5,9.05,0 L128,153.722l52.223-52.22c2.496-2.5,6.553-2.5,9.049,0c2.5,2.499,2.5,6.552,0,9.05l-56.746,56.747 C131.277,168.549,129.638,169.174,128,169.174z M256,128C256,57.42,198.58,0,128,0C57.42,0,0,57.42,0,128c0,70.58,57.42,128,128,128 C198.58,256,256,198.58,256,128z M243.2,128c0,63.521-51.679,115.2-115.2,115.2c-63.522,0-115.2-51.679-115.2-115.2 C12.8,64.478,64.478,12.8,128,12.8C191.521,12.8,243.2,64.478,243.2,128z"></path></svg><svg aria-hidden="true" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" class="svg-icon-15px zpaccord-svg-icon-3"><path d="M256,298.3L256,298.3L256,298.3l174.2-167.2c4.3-4.2,11.4-4.1,15.8,0.2l30.6,29.9c4.4,4.3,4.5,11.3,0.2,15.5L264.1,380.9c-2.2,2.2-5.2,3.2-8.1,3c-3,0.1-5.9-0.9-8.1-3L35.2,176.7c-4.3-4.2-4.2-11.2,0.2-15.5L66,131.3c4.4-4.3,11.5-4.4,15.8-0.2L256,298.3z"/></svg><svg aria-hidden="true" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" class="svg-icon-15px zpaccord-svg-icon-4"><path d="M417.4,224H288V94.6c0-16.9-14.3-30.6-32-30.6c-17.7,0-32,13.7-32,30.6V224H94.6C77.7,224,64,238.3,64,256 c0,17.7,13.7,32,30.6,32H224v129.4c0,16.9,14.3,30.6,32,30.6c17.7,0,32-13.7,32-30.6V288h129.4c16.9,0,30.6-14.3,30.6-32 C448,238.3,434.3,224,417.4,224z"></path></svg></span><span class="zpaccordionicon zpaccord-icon-active"><svg aria-hidden="true" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" class="svg-icon-15px zpaccord-svg-icon-1"><path d="M413.1,327.3l-1.8-2.1l-136-156.5c-4.6-5.3-11.5-8.6-19.2-8.6c-7.7,0-14.6,3.4-19.2,8.6L101,324.9l-2.3,2.6 C97,330,96,333,96,336.2c0,8.7,7.4,15.8,16.6,15.8v0h286.8v0c9.2,0,16.6-7.1,16.6-15.8C416,332.9,414.9,329.8,413.1,327.3z"></path></svg><svg aria-hidden="true" viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg" class="svg-icon-15px zpaccord-svg-icon-2"><path d="M184.746,156.373c-1.639,0-3.275-0.625-4.525-1.875L128,102.278l-52.223,52.22c-2.497,2.5-6.55,2.5-9.05,0 c-2.5-2.498-2.5-6.551,0-9.05l56.749-56.747c1.2-1.2,2.828-1.875,4.525-1.875l0,0c1.697,0,3.325,0.675,4.525,1.875l56.745,56.747 c2.5,2.499,2.5,6.552,0,9.05C188.021,155.748,186.383,156.373,184.746,156.373z M256,128C256,57.42,198.58,0,128,0 C57.42,0,0,57.42,0,128c0,70.58,57.42,128,128,128C198.58,256,256,198.58,256,128z M243.2,128c0,63.521-51.679,115.2-115.2,115.2 c-63.522,0-115.2-51.679-115.2-115.2C12.8,64.478,64.478,12.8,128,12.8C191.521,12.8,243.2,64.478,243.2,128z"></path></svg><svg aria-hidden="true" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" class="svg-icon-15px zpaccord-svg-icon-3"><path d="M256,213.7L256,213.7L256,213.7l174.2,167.2c4.3,4.2,11.4,4.1,15.8-0.2l30.6-29.9c4.4-4.3,4.5-11.3,0.2-15.5L264.1,131.1c-2.2-2.2-5.2-3.2-8.1-3c-3-0.1-5.9,0.9-8.1,3L35.2,335.3c-4.3,4.2-4.2,11.2,0.2,15.5L66,380.7c4.4,4.3,11.5,4.4,15.8,0.2L256,213.7z"/></svg><svg aria-hidden="true" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" class="svg-icon-15px zpaccord-svg-icon-4"><path d="M417.4,224H94.6C77.7,224,64,238.3,64,256c0,17.7,13.7,32,30.6,32h322.8c16.9,0,30.6-14.3,30.6-32 C448,238.3,434.3,224,417.4,224z"></path></svg></span></div>
-<div data-element-id="elm_83IrP4v9xihlitbCBsvqYQ" data-element-type="accordioncontainer" class="zpelement zpaccordion-content " style="margin-top:0;"><div class="zpaccordion-element-container"><div data-element-id="elm_dhaKm-ySoDjKWaFn1rjmDQ" data-element-type="row" class="zprow zprow-container zpalign-items-flex-start zpjustify-content-flex-start zpdefault-section zpdefault-section-bg " data-equal-column="false"><style type="text/css"></style><div data-element-id="elm_DpCOjfU3rKfBbUwen97n7Q" data-element-type="column" class="zpelem-col zpcol-12 zpcol-md-12 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg "><style type="text/css"></style><div data-element-id="elm_k2n6jcvwWZ3PCl_NV1NvnQ" data-element-type="text" class="zpelement zpelem-text "><style></style><div class="zptext zptext-align-left zptext-align-mobile-left zptext-align-tablet-left " data-editor="true"><div style="color:inherit;"><div>WPA Enterprise is a Wi-Fi security protocol that provides enterprise-level security for wireless networks. It is an improvement over the more common WPA-PSK (Pre-Shared Key) protocol, which is used for home and small office networks.</div><div><p>The main difference between WPA-PSK and WPA Enterprise is the authentication method used. WPA-PSK uses a single shared password for all users to authenticate themselves to the network, while WPA Enterprise uses a more robust authentication method that involves a RADIUS (Remote Authentication Dial-In User Service) server.</p><p>In WPA Enterprise, each user is assigned their own unique username and password, which they use to authenticate themselves to the network. The RADIUS server acts as a central authentication server, verifying each user's credentials before allowing them to access the network. This provides a higher level of security, as it ensures that only authorized users can access the network.</p><p>WPA Enterprise also supports additional security features, such as 802.1X port-based access control, which allows administrators to control access to specific ports on the network based on a user's authentication status. This can help prevent unauthorized access and protect against attacks such as port scanning.</p><p>Overall, WPA Enterprise provides a higher level of security than WPA-PSK, making it a better choice for enterprise-level wireless networks where security is a top priority. However, implementing WPA Enterprise requires additional infrastructure and expertise, as it involves setting up a RADIUS server and configuring network devices to support 802.1X authentication.</p></div></div></div>
-</div></div></div></div></div><div data-element-id="elm_inHJgM1In7xJK_skIqkm3w" data-element-type="accordionheader" class="zpelement zpaccordion " data-tab-name="Why is WPA Enterprise Level Security Important?" data-content-id="elm_952LoFb1dsy9ogYvxW1ZZg" style="margin-top:0;" tabindex="0" role="button" aria-label="Why is WPA Enterprise Level Security Important?"><span class="zpaccordion-name">Why is WPA Enterprise Level Security Important?</span><span class="zpaccordionicon zpaccord-icon-inactive"><svg aria-hidden="true" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" class="svg-icon-15px zpaccord-svg-icon-1"><path d="M98.9,184.7l1.8,2.1l136,156.5c4.6,5.3,11.5,8.6,19.2,8.6c7.7,0,14.6-3.4,19.2-8.6L411,187.1l2.3-2.6 c1.7-2.5,2.7-5.5,2.7-8.7c0-8.7-7.4-15.8-16.6-15.8v0H112.6v0c-9.2,0-16.6,7.1-16.6,15.8C96,179.1,97.1,182.2,98.9,184.7z"></path></svg><svg aria-hidden="true" viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg" class="svg-icon-15px zpaccord-svg-icon-2"><path d="M128,169.174c-1.637,0-3.276-0.625-4.525-1.875l-56.747-56.747c-2.5-2.499-2.5-6.552,0-9.05c2.497-2.5,6.553-2.5,9.05,0 L128,153.722l52.223-52.22c2.496-2.5,6.553-2.5,9.049,0c2.5,2.499,2.5,6.552,0,9.05l-56.746,56.747 C131.277,168.549,129.638,169.174,128,169.174z M256,128C256,57.42,198.58,0,128,0C57.42,0,0,57.42,0,128c0,70.58,57.42,128,128,128 C198.58,256,256,198.58,256,128z M243.2,128c0,63.521-51.679,115.2-115.2,115.2c-63.522,0-115.2-51.679-115.2-115.2 C12.8,64.478,64.478,12.8,128,12.8C191.521,12.8,243.2,64.478,243.2,128z"></path></svg><svg aria-hidden="true" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" class="svg-icon-15px zpaccord-svg-icon-3"><path d="M256,298.3L256,298.3L256,298.3l174.2-167.2c4.3-4.2,11.4-4.1,15.8,0.2l30.6,29.9c4.4,4.3,4.5,11.3,0.2,15.5L264.1,380.9c-2.2,2.2-5.2,3.2-8.1,3c-3,0.1-5.9-0.9-8.1-3L35.2,176.7c-4.3-4.2-4.2-11.2,0.2-15.5L66,131.3c4.4-4.3,11.5-4.4,15.8-0.2L256,298.3z"/></svg><svg aria-hidden="true" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" class="svg-icon-15px zpaccord-svg-icon-4"><path d="M417.4,224H288V94.6c0-16.9-14.3-30.6-32-30.6c-17.7,0-32,13.7-32,30.6V224H94.6C77.7,224,64,238.3,64,256 c0,17.7,13.7,32,30.6,32H224v129.4c0,16.9,14.3,30.6,32,30.6c17.7,0,32-13.7,32-30.6V288h129.4c16.9,0,30.6-14.3,30.6-32 C448,238.3,434.3,224,417.4,224z"></path></svg></span><span class="zpaccordionicon zpaccord-icon-active"><svg aria-hidden="true" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" class="svg-icon-15px zpaccord-svg-icon-1"><path d="M413.1,327.3l-1.8-2.1l-136-156.5c-4.6-5.3-11.5-8.6-19.2-8.6c-7.7,0-14.6,3.4-19.2,8.6L101,324.9l-2.3,2.6 C97,330,96,333,96,336.2c0,8.7,7.4,15.8,16.6,15.8v0h286.8v0c9.2,0,16.6-7.1,16.6-15.8C416,332.9,414.9,329.8,413.1,327.3z"></path></svg><svg aria-hidden="true" viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg" class="svg-icon-15px zpaccord-svg-icon-2"><path d="M184.746,156.373c-1.639,0-3.275-0.625-4.525-1.875L128,102.278l-52.223,52.22c-2.497,2.5-6.55,2.5-9.05,0 c-2.5-2.498-2.5-6.551,0-9.05l56.749-56.747c1.2-1.2,2.828-1.875,4.525-1.875l0,0c1.697,0,3.325,0.675,4.525,1.875l56.745,56.747 c2.5,2.499,2.5,6.552,0,9.05C188.021,155.748,186.383,156.373,184.746,156.373z M256,128C256,57.42,198.58,0,128,0 C57.42,0,0,57.42,0,128c0,70.58,57.42,128,128,128C198.58,256,256,198.58,256,128z M243.2,128c0,63.521-51.679,115.2-115.2,115.2 c-63.522,0-115.2-51.679-115.2-115.2C12.8,64.478,64.478,12.8,128,12.8C191.521,12.8,243.2,64.478,243.2,128z"></path></svg><svg aria-hidden="true" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" class="svg-icon-15px zpaccord-svg-icon-3"><path d="M256,213.7L256,213.7L256,213.7l174.2,167.2c4.3,4.2,11.4,4.1,15.8-0.2l30.6-29.9c4.4-4.3,4.5-11.3,0.2-15.5L264.1,131.1c-2.2-2.2-5.2-3.2-8.1-3c-3-0.1-5.9,0.9-8.1,3L35.2,335.3c-4.3,4.2-4.2,11.2,0.2,15.5L66,380.7c4.4,4.3,11.5,4.4,15.8,0.2L256,213.7z"/></svg><svg aria-hidden="true" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" class="svg-icon-15px zpaccord-svg-icon-4"><path d="M417.4,224H94.6C77.7,224,64,238.3,64,256c0,17.7,13.7,32,30.6,32h322.8c16.9,0,30.6-14.3,30.6-32 C448,238.3,434.3,224,417.4,224z"></path></svg></span></div>
-<div data-element-id="elm_952LoFb1dsy9ogYvxW1ZZg" data-element-type="accordioncontainer" class="zpelement zpaccordion-content " style="margin-top:0;"><div class="zpaccordion-element-container"><div data-element-id="elm_LG7Ls2JALHYjW60E1SNzzg" data-element-type="row" class="zprow zprow-container zpalign-items-flex-start zpjustify-content-flex-start zpdefault-section zpdefault-section-bg " data-equal-column="false"><style type="text/css"></style><div data-element-id="elm_gw5jF3J8PVGynydB_ITmWA" data-element-type="column" class="zpelem-col zpcol-12 zpcol-md-12 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg "><style type="text/css"></style><div data-element-id="elm_lSFtpNrY7MkvMSTRMTjZDw" data-element-type="text" class="zpelement zpelem-text "><style></style><div class="zptext zptext-align-left zptext-align-mobile-left zptext-align-tablet-left " data-editor="true"><div style="color:inherit;"><p>WPA Enterprise level security is important because it provides a higher level of security than other Wi-Fi security protocols, especially for enterprise-level wireless networks. Here are some reasons why WPA Enterprise level security is important:</p><ol><li><p>Stronger authentication: WPA Enterprise uses a more robust authentication method that involves a RADIUS server, which provides each user with a unique username and password. This makes it more difficult for attackers to gain unauthorized access to the network.</p></li><li><p>Individualized access control: Each user's credentials are verified by the RADIUS server, which ensures that only authorized users can access the network. This allows for more granular access control and helps prevent unauthorized access to the network.</p></li><li><p>Better protection against attacks: WPA Enterprise supports additional security features, such as 802.1X port-based access control, which can help protect against attacks such as port scanning and other types of network-based attacks.</p></li><li><p>Compliance: In many industries, such as finance, healthcare, and government, there are regulations that require the use of stronger security protocols for wireless networks. WPA Enterprise helps ensure compliance with these regulations.</p></li><li><p>Reputation: A security breach can damage a business's reputation and erode customer trust. By implementing WPA Enterprise level security, businesses can demonstrate their commitment to security and protect their reputation.</p></li></ol><p>Overall, WPA Enterprise level security is important because it provides a higher level of security for wireless networks, especially for enterprise-level networks where security is a top priority. By implementing WPA Enterprise level security, businesses can protect their networks, their customers, and their reputation.</p></div></div>
-</div></div></div></div></div><div data-element-id="elm_iHnXP4JN2dOU385ocJvV2Q" data-element-type="accordionheader" class="zpelement zpaccordion " data-tab-name="How Can IronWiFi's WPA Enterprise Security Help My Business?" data-content-id="elm_0_SRHVETb-bu69Ax7W6BqA" style="margin-top:0;" tabindex="0" role="button" aria-label="How Can IronWiFi's WPA Enterprise Security Help My Business?"><span class="zpaccordion-name">How Can IronWiFi's WPA Enterprise Security Help My Business?</span><span class="zpaccordionicon zpaccord-icon-inactive"><svg aria-hidden="true" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" class="svg-icon-15px zpaccord-svg-icon-1"><path d="M98.9,184.7l1.8,2.1l136,156.5c4.6,5.3,11.5,8.6,19.2,8.6c7.7,0,14.6-3.4,19.2-8.6L411,187.1l2.3-2.6 c1.7-2.5,2.7-5.5,2.7-8.7c0-8.7-7.4-15.8-16.6-15.8v0H112.6v0c-9.2,0-16.6,7.1-16.6,15.8C96,179.1,97.1,182.2,98.9,184.7z"></path></svg><svg aria-hidden="true" viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg" class="svg-icon-15px zpaccord-svg-icon-2"><path d="M128,169.174c-1.637,0-3.276-0.625-4.525-1.875l-56.747-56.747c-2.5-2.499-2.5-6.552,0-9.05c2.497-2.5,6.553-2.5,9.05,0 L128,153.722l52.223-52.22c2.496-2.5,6.553-2.5,9.049,0c2.5,2.499,2.5,6.552,0,9.05l-56.746,56.747 C131.277,168.549,129.638,169.174,128,169.174z M256,128C256,57.42,198.58,0,128,0C57.42,0,0,57.42,0,128c0,70.58,57.42,128,128,128 C198.58,256,256,198.58,256,128z M243.2,128c0,63.521-51.679,115.2-115.2,115.2c-63.522,0-115.2-51.679-115.2-115.2 C12.8,64.478,64.478,12.8,128,12.8C191.521,12.8,243.2,64.478,243.2,128z"></path></svg><svg aria-hidden="true" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" class="svg-icon-15px zpaccord-svg-icon-3"><path d="M256,298.3L256,298.3L256,298.3l174.2-167.2c4.3-4.2,11.4-4.1,15.8,0.2l30.6,29.9c4.4,4.3,4.5,11.3,0.2,15.5L264.1,380.9c-2.2,2.2-5.2,3.2-8.1,3c-3,0.1-5.9-0.9-8.1-3L35.2,176.7c-4.3-4.2-4.2-11.2,0.2-15.5L66,131.3c4.4-4.3,11.5-4.4,15.8-0.2L256,298.3z"/></svg><svg aria-hidden="true" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" class="svg-icon-15px zpaccord-svg-icon-4"><path d="M417.4,224H288V94.6c0-16.9-14.3-30.6-32-30.6c-17.7,0-32,13.7-32,30.6V224H94.6C77.7,224,64,238.3,64,256 c0,17.7,13.7,32,30.6,32H224v129.4c0,16.9,14.3,30.6,32,30.6c17.7,0,32-13.7,32-30.6V288h129.4c16.9,0,30.6-14.3,30.6-32 C448,238.3,434.3,224,417.4,224z"></path></svg></span><span class="zpaccordionicon zpaccord-icon-active"><svg aria-hidden="true" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" class="svg-icon-15px zpaccord-svg-icon-1"><path d="M413.1,327.3l-1.8-2.1l-136-156.5c-4.6-5.3-11.5-8.6-19.2-8.6c-7.7,0-14.6,3.4-19.2,8.6L101,324.9l-2.3,2.6 C97,330,96,333,96,336.2c0,8.7,7.4,15.8,16.6,15.8v0h286.8v0c9.2,0,16.6-7.1,16.6-15.8C416,332.9,414.9,329.8,413.1,327.3z"></path></svg><svg aria-hidden="true" viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg" class="svg-icon-15px zpaccord-svg-icon-2"><path d="M184.746,156.373c-1.639,0-3.275-0.625-4.525-1.875L128,102.278l-52.223,52.22c-2.497,2.5-6.55,2.5-9.05,0 c-2.5-2.498-2.5-6.551,0-9.05l56.749-56.747c1.2-1.2,2.828-1.875,4.525-1.875l0,0c1.697,0,3.325,0.675,4.525,1.875l56.745,56.747 c2.5,2.499,2.5,6.552,0,9.05C188.021,155.748,186.383,156.373,184.746,156.373z M256,128C256,57.42,198.58,0,128,0 C57.42,0,0,57.42,0,128c0,70.58,57.42,128,128,128C198.58,256,256,198.58,256,128z M243.2,128c0,63.521-51.679,115.2-115.2,115.2 c-63.522,0-115.2-51.679-115.2-115.2C12.8,64.478,64.478,12.8,128,12.8C191.521,12.8,243.2,64.478,243.2,128z"></path></svg><svg aria-hidden="true" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" class="svg-icon-15px zpaccord-svg-icon-3"><path d="M256,213.7L256,213.7L256,213.7l174.2,167.2c4.3,4.2,11.4,4.1,15.8-0.2l30.6-29.9c4.4-4.3,4.5-11.3,0.2-15.5L264.1,131.1c-2.2-2.2-5.2-3.2-8.1-3c-3-0.1-5.9,0.9-8.1,3L35.2,335.3c-4.3,4.2-4.2,11.2,0.2,15.5L66,380.7c4.4,4.3,11.5,4.4,15.8,0.2L256,213.7z"/></svg><svg aria-hidden="true" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" class="svg-icon-15px zpaccord-svg-icon-4"><path d="M417.4,224H94.6C77.7,224,64,238.3,64,256c0,17.7,13.7,32,30.6,32h322.8c16.9,0,30.6-14.3,30.6-32 C448,238.3,434.3,224,417.4,224z"></path></svg></span></div>
-<div data-element-id="elm_0_SRHVETb-bu69Ax7W6BqA" data-element-type="accordioncontainer" class="zpelement zpaccordion-content " style="margin-top:0;"><div class="zpaccordion-element-container"><div data-element-id="elm_52hftUGY5bTiZs683TEhew" data-element-type="row" class="zprow zprow-container zpalign-items-flex-start zpjustify-content-flex-start zpdefault-section zpdefault-section-bg " data-equal-column="false"><style type="text/css"></style><div data-element-id="elm_cB7VlAt43YfMPuu26D3dfA" data-element-type="column" class="zpelem-col zpcol-12 zpcol-md-12 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg "><style type="text/css"></style><div data-element-id="elm_vwbMZYSz98L03YxheTOScQ" data-element-type="text" class="zpelement zpelem-text "><style></style><div class="zptext zptext-align-left zptext-align-mobile-left zptext-align-tablet-left " data-editor="true"><div style="color:inherit;"><p>IronWiFi's WPA Enterprise level security helps businesses in several ways:</p><ol><li><p>Strong authentication: WPA Enterprise provides strong authentication through the use of digital certificates, which helps to prevent unauthorized access to the network. This ensures that only authorized users can connect to the network, and helps to protect against security threats such as hacking, eavesdropping, and man-in-the-middle attacks.</p></li><li><p>Centralized management: WPA Enterprise provides centralized management of network access, which makes it easy for businesses to control who has access to the network and to enforce security policies. This reduces the burden on IT staff and helps to ensure that security policies are consistently applied across the network.</p></li><li><p>Scalability: WPA Enterprise is highly scalable, making it well-suited for large businesses with many users and devices. The system can easily accommodate new users and devices, and can be integrated with existing IT infrastructure.</p></li><li><p>Compliance: Many industries have specific security and privacy regulations that businesses must comply with, such as HIPAA in healthcare and PCI-DSS in the payment card industry. WPA Enterprise can help businesses meet these requirements by providing strong security controls and audit trails.</p></li><li><p>Improved productivity: By providing a secure and reliable network, WPA Enterprise can help to improve productivity and reduce downtime. This can have a positive impact on the bottom line of businesses, especially those that rely heavily on their IT systems.</p></li></ol><p>Overall, IronWiFi's WPA Enterprise level security can help businesses by providing strong authentication, centralized management, scalability, compliance with regulations, and improved productivity.</p></div></div>
-</div></div></div></div></div><div data-element-id="elm_AUNqAUWt6GzqEurctgGp9w" data-element-type="accordionheader" class="zpelement zpaccordion " data-tab-name=" Distribution of Security Certificates" data-content-id="elm_FMQv2s44Rit3KOuD2KVAPg" style="margin-top:0;" tabindex="0" role="button" aria-label=" Distribution of Security Certificates"><span class="zpaccordion-name"> Distribution of Security Certificates</span><span class="zpaccordionicon zpaccord-icon-inactive"><svg aria-hidden="true" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" class="svg-icon-15px zpaccord-svg-icon-1"><path d="M98.9,184.7l1.8,2.1l136,156.5c4.6,5.3,11.5,8.6,19.2,8.6c7.7,0,14.6-3.4,19.2-8.6L411,187.1l2.3-2.6 c1.7-2.5,2.7-5.5,2.7-8.7c0-8.7-7.4-15.8-16.6-15.8v0H112.6v0c-9.2,0-16.6,7.1-16.6,15.8C96,179.1,97.1,182.2,98.9,184.7z"></path></svg><svg aria-hidden="true" viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg" class="svg-icon-15px zpaccord-svg-icon-2"><path d="M128,169.174c-1.637,0-3.276-0.625-4.525-1.875l-56.747-56.747c-2.5-2.499-2.5-6.552,0-9.05c2.497-2.5,6.553-2.5,9.05,0 L128,153.722l52.223-52.22c2.496-2.5,6.553-2.5,9.049,0c2.5,2.499,2.5,6.552,0,9.05l-56.746,56.747 C131.277,168.549,129.638,169.174,128,169.174z M256,128C256,57.42,198.58,0,128,0C57.42,0,0,57.42,0,128c0,70.58,57.42,128,128,128 C198.58,256,256,198.58,256,128z M243.2,128c0,63.521-51.679,115.2-115.2,115.2c-63.522,0-115.2-51.679-115.2-115.2 C12.8,64.478,64.478,12.8,128,12.8C191.521,12.8,243.2,64.478,243.2,128z"></path></svg><svg aria-hidden="true" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" class="svg-icon-15px zpaccord-svg-icon-3"><path d="M256,298.3L256,298.3L256,298.3l174.2-167.2c4.3-4.2,11.4-4.1,15.8,0.2l30.6,29.9c4.4,4.3,4.5,11.3,0.2,15.5L264.1,380.9c-2.2,2.2-5.2,3.2-8.1,3c-3,0.1-5.9-0.9-8.1-3L35.2,176.7c-4.3-4.2-4.2-11.2,0.2-15.5L66,131.3c4.4-4.3,11.5-4.4,15.8-0.2L256,298.3z"/></svg><svg aria-hidden="true" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" class="svg-icon-15px zpaccord-svg-icon-4"><path d="M417.4,224H288V94.6c0-16.9-14.3-30.6-32-30.6c-17.7,0-32,13.7-32,30.6V224H94.6C77.7,224,64,238.3,64,256 c0,17.7,13.7,32,30.6,32H224v129.4c0,16.9,14.3,30.6,32,30.6c17.7,0,32-13.7,32-30.6V288h129.4c16.9,0,30.6-14.3,30.6-32 C448,238.3,434.3,224,417.4,224z"></path></svg></span><span class="zpaccordionicon zpaccord-icon-active"><svg aria-hidden="true" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" class="svg-icon-15px zpaccord-svg-icon-1"><path d="M413.1,327.3l-1.8-2.1l-136-156.5c-4.6-5.3-11.5-8.6-19.2-8.6c-7.7,0-14.6,3.4-19.2,8.6L101,324.9l-2.3,2.6 C97,330,96,333,96,336.2c0,8.7,7.4,15.8,16.6,15.8v0h286.8v0c9.2,0,16.6-7.1,16.6-15.8C416,332.9,414.9,329.8,413.1,327.3z"></path></svg><svg aria-hidden="true" viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg" class="svg-icon-15px zpaccord-svg-icon-2"><path d="M184.746,156.373c-1.639,0-3.275-0.625-4.525-1.875L128,102.278l-52.223,52.22c-2.497,2.5-6.55,2.5-9.05,0 c-2.5-2.498-2.5-6.551,0-9.05l56.749-56.747c1.2-1.2,2.828-1.875,4.525-1.875l0,0c1.697,0,3.325,0.675,4.525,1.875l56.745,56.747 c2.5,2.499,2.5,6.552,0,9.05C188.021,155.748,186.383,156.373,184.746,156.373z M256,128C256,57.42,198.58,0,128,0 C57.42,0,0,57.42,0,128c0,70.58,57.42,128,128,128C198.58,256,256,198.58,256,128z M243.2,128c0,63.521-51.679,115.2-115.2,115.2 c-63.522,0-115.2-51.679-115.2-115.2C12.8,64.478,64.478,12.8,128,12.8C191.521,12.8,243.2,64.478,243.2,128z"></path></svg><svg aria-hidden="true" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" class="svg-icon-15px zpaccord-svg-icon-3"><path d="M256,213.7L256,213.7L256,213.7l174.2,167.2c4.3,4.2,11.4,4.1,15.8-0.2l30.6-29.9c4.4-4.3,4.5-11.3,0.2-15.5L264.1,131.1c-2.2-2.2-5.2-3.2-8.1-3c-3-0.1-5.9,0.9-8.1,3L35.2,335.3c-4.3,4.2-4.2,11.2,0.2,15.5L66,380.7c4.4,4.3,11.5,4.4,15.8,0.2L256,213.7z"/></svg><svg aria-hidden="true" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" class="svg-icon-15px zpaccord-svg-icon-4"><path d="M417.4,224H94.6C77.7,224,64,238.3,64,256c0,17.7,13.7,32,30.6,32h322.8c16.9,0,30.6-14.3,30.6-32 C448,238.3,434.3,224,417.4,224z"></path></svg></span></div>
-<div data-element-id="elm_FMQv2s44Rit3KOuD2KVAPg" data-element-type="accordioncontainer" class="zpelement zpaccordion-content " style="margin-top:0;"><div class="zpaccordion-element-container"><div data-element-id="elm_lSNOalEu8AnuiCMZaD6r3A" data-element-type="row" class="zprow zprow-container zpalign-items-flex-start zpjustify-content-flex-start zpdefault-section zpdefault-section-bg " data-equal-column="false"><style type="text/css"></style><div data-element-id="elm_9X43Ly5oXzCIrSWBNRk-Cw" data-element-type="column" class="zpelem-col zpcol-12 zpcol-md-12 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg "><style type="text/css"></style><div data-element-id="elm_0AMpDs8TadrbyxOAXJSreQ" data-element-type="text" class="zpelement zpelem-text "><style></style><div class="zptext zptext-align-left zptext-align-mobile-left zptext-align-tablet-left " data-editor="true"><div style="color:inherit;"><div style="color:inherit;"><div><div><br/></div><div></div></div><div><div><h3 style="font-size:24px;"><p>Distribution of Security Certificates</p></h3></div><div><div><p>Security certificates need to be installed on the user’s device in order to connect to the network. Once installed, the users device will seamlessly connect to the network, removing the need for the user to enter their username and password every time they wish to connect.</p><p>Three options are available to obtain the generated certificate:</p><ul><li><span style="font-weight:700;">Download certificate</span>&nbsp;– the certificate will be automatically downloaded to the administrator’s browser. An import password will be displayed in the pop-up window.</li><li><span style="font-weight:700;">Email certificate to the user</span>&nbsp;– The user will obtain an email with a certificate in the attachment. An import password is included in the email. This method requires the user to have a valid email address.</li><li><span style="font-weight:700;">Email download link to the user</span>&nbsp;– an email is sent to the user with an import password and a link to download the certificate. The certificate can be downloaded only once. A valid email address in the user profile is required to deliver the email.</li></ul><p>OR</p><p>use a SCEP server to issue certificates in real time.</p></div></div></div></div></div></div>
-</div></div></div></div></div><div data-element-id="elm_B7dHNhjK_vZWs8Zpu8oYew" data-element-type="accordionheader" class="zpelement zpaccordion " data-tab-name="External Identity Providers" data-content-id="elm_XJro8jVBEkUi_BTIXvzH1g" style="margin-top:0;" tabindex="0" role="button" aria-label="External Identity Providers"><span class="zpaccordion-name">External Identity Providers</span><span class="zpaccordionicon zpaccord-icon-inactive"><svg aria-hidden="true" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" class="svg-icon-15px zpaccord-svg-icon-1"><path d="M98.9,184.7l1.8,2.1l136,156.5c4.6,5.3,11.5,8.6,19.2,8.6c7.7,0,14.6-3.4,19.2-8.6L411,187.1l2.3-2.6 c1.7-2.5,2.7-5.5,2.7-8.7c0-8.7-7.4-15.8-16.6-15.8v0H112.6v0c-9.2,0-16.6,7.1-16.6,15.8C96,179.1,97.1,182.2,98.9,184.7z"></path></svg><svg aria-hidden="true" viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg" class="svg-icon-15px zpaccord-svg-icon-2"><path d="M128,169.174c-1.637,0-3.276-0.625-4.525-1.875l-56.747-56.747c-2.5-2.499-2.5-6.552,0-9.05c2.497-2.5,6.553-2.5,9.05,0 L128,153.722l52.223-52.22c2.496-2.5,6.553-2.5,9.049,0c2.5,2.499,2.5,6.552,0,9.05l-56.746,56.747 C131.277,168.549,129.638,169.174,128,169.174z M256,128C256,57.42,198.58,0,128,0C57.42,0,0,57.42,0,128c0,70.58,57.42,128,128,128 C198.58,256,256,198.58,256,128z M243.2,128c0,63.521-51.679,115.2-115.2,115.2c-63.522,0-115.2-51.679-115.2-115.2 C12.8,64.478,64.478,12.8,128,12.8C191.521,12.8,243.2,64.478,243.2,128z"></path></svg><svg aria-hidden="true" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" class="svg-icon-15px zpaccord-svg-icon-3"><path d="M256,298.3L256,298.3L256,298.3l174.2-167.2c4.3-4.2,11.4-4.1,15.8,0.2l30.6,29.9c4.4,4.3,4.5,11.3,0.2,15.5L264.1,380.9c-2.2,2.2-5.2,3.2-8.1,3c-3,0.1-5.9-0.9-8.1-3L35.2,176.7c-4.3-4.2-4.2-11.2,0.2-15.5L66,131.3c4.4-4.3,11.5-4.4,15.8-0.2L256,298.3z"/></svg><svg aria-hidden="true" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" class="svg-icon-15px zpaccord-svg-icon-4"><path d="M417.4,224H288V94.6c0-16.9-14.3-30.6-32-30.6c-17.7,0-32,13.7-32,30.6V224H94.6C77.7,224,64,238.3,64,256 c0,17.7,13.7,32,30.6,32H224v129.4c0,16.9,14.3,30.6,32,30.6c17.7,0,32-13.7,32-30.6V288h129.4c16.9,0,30.6-14.3,30.6-32 C448,238.3,434.3,224,417.4,224z"></path></svg></span><span class="zpaccordionicon zpaccord-icon-active"><svg aria-hidden="true" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" class="svg-icon-15px zpaccord-svg-icon-1"><path d="M413.1,327.3l-1.8-2.1l-136-156.5c-4.6-5.3-11.5-8.6-19.2-8.6c-7.7,0-14.6,3.4-19.2,8.6L101,324.9l-2.3,2.6 C97,330,96,333,96,336.2c0,8.7,7.4,15.8,16.6,15.8v0h286.8v0c9.2,0,16.6-7.1,16.6-15.8C416,332.9,414.9,329.8,413.1,327.3z"></path></svg><svg aria-hidden="true" viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg" class="svg-icon-15px zpaccord-svg-icon-2"><path d="M184.746,156.373c-1.639,0-3.275-0.625-4.525-1.875L128,102.278l-52.223,52.22c-2.497,2.5-6.55,2.5-9.05,0 c-2.5-2.498-2.5-6.551,0-9.05l56.749-56.747c1.2-1.2,2.828-1.875,4.525-1.875l0,0c1.697,0,3.325,0.675,4.525,1.875l56.745,56.747 c2.5,2.499,2.5,6.552,0,9.05C188.021,155.748,186.383,156.373,184.746,156.373z M256,128C256,57.42,198.58,0,128,0 C57.42,0,0,57.42,0,128c0,70.58,57.42,128,128,128C198.58,256,256,198.58,256,128z M243.2,128c0,63.521-51.679,115.2-115.2,115.2 c-63.522,0-115.2-51.679-115.2-115.2C12.8,64.478,64.478,12.8,128,12.8C191.521,12.8,243.2,64.478,243.2,128z"></path></svg><svg aria-hidden="true" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" class="svg-icon-15px zpaccord-svg-icon-3"><path d="M256,213.7L256,213.7L256,213.7l174.2,167.2c4.3,4.2,11.4,4.1,15.8-0.2l30.6-29.9c4.4-4.3,4.5-11.3,0.2-15.5L264.1,131.1c-2.2-2.2-5.2-3.2-8.1-3c-3-0.1-5.9,0.9-8.1,3L35.2,335.3c-4.3,4.2-4.2,11.2,0.2,15.5L66,380.7c4.4,4.3,11.5,4.4,15.8,0.2L256,213.7z"/></svg><svg aria-hidden="true" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" class="svg-icon-15px zpaccord-svg-icon-4"><path d="M417.4,224H94.6C77.7,224,64,238.3,64,256c0,17.7,13.7,32,30.6,32h322.8c16.9,0,30.6-14.3,30.6-32 C448,238.3,434.3,224,417.4,224z"></path></svg></span></div>
-<div data-element-id="elm_XJro8jVBEkUi_BTIXvzH1g" data-element-type="accordioncontainer" class="zpelement zpaccordion-content " style="margin-top:0;"><div class="zpaccordion-element-container"><div data-element-id="elm_cVfa1QzERmD7HTyJkzDbNw" data-element-type="row" class="zprow zprow-container zpalign-items-flex-start zpjustify-content-flex-start zpdefault-section zpdefault-section-bg " data-equal-column="false"><style type="text/css"></style><div data-element-id="elm_rPs6iQmZzklbrQUnbYT-9w" data-element-type="column" class="zpelem-col zpcol-12 zpcol-md-12 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg "><style type="text/css"></style><div data-element-id="elm_Flb77-ZdZZuj3ge9L61UTw" data-element-type="text" class="zpelement zpelem-text "><style></style><div class="zptext zptext-align-left zptext-align-mobile-left zptext-align-tablet-left " data-editor="true"><p><span style="color:inherit;">IronWifi allows for simple integration of external identity providers. By creating a &quot;Connector&quot;, you can import all your employees or students in one click. Real-time synchronization is what allows us to stay up to date with your active directory. A few examples of the identity providers / databases we integrate with include Azure, Google, REST API (custom), LDAP.</span></p></div>
-</div></div></div></div></div></div></div></div></div></div></div><div data-element-id="elm_PGngkk8L1C7Iie8yJTP7qA" data-element-type="section" class="zpsection zpdefault-section zpdefault-section-bg "><style type="text/css"> [data-element-id="elm_PGngkk8L1C7Iie8yJTP7qA"].zpsection{ padding-block-start:27px; } </style><div class="zpcontainer-fluid zpcontainer"><div data-element-id="elm_FUTLmhmkZn5B-rYyOaubwA" data-element-type="row" class="zprow zprow-container zpalign-items-center zpjustify-content-flex-start " data-equal-column=""><style type="text/css"></style><div data-element-id="elm_WgjDS8762NEtGAnmb33XLw" data-element-type="column" class="zpelem-col zpcol-12 zpcol-md-4 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg "><style type="text/css"></style><div data-element-id="elm_7Wcx0J1VIwiGk9czqJMsqA" data-element-type="image" class="zpelement zpelem-image "><style> @media (min-width: 992px) { [data-element-id="elm_7Wcx0J1VIwiGk9czqJMsqA"] .zpimage-container figure img { width: 318px !important ; height: 318px !important ; } } [data-element-id="elm_7Wcx0J1VIwiGk9czqJMsqA"].zpelem-image { margin-block-start:-1px; } </style><div data-caption-color="" data-size-tablet="" data-size-mobile="" data-align="center" data-tablet-image-separate="false" data-mobile-image-separate="false" class="zpimage-container zpimage-align-center zpimage-tablet-align-center zpimage-mobile-align-center zpimage-size-custom zpimage-tablet-fallback-fit zpimage-mobile-fallback-fit hb-lightbox " data-lightbox-options="
+                theme:dark" data-mobile-image-separate="false" data-size-mobile="" data-size-tablet="" data-tablet-image-separate="false">
+              <figure class="zpimage-data-ref" role="none">
+               <span aria-label="Open Lightbox" class="zpimage-anchor" role="link" style="cursor:pointer;" tabindex="0">
+                <picture>
+                 <img alt="Wireless access point" class="zpimage zpimage-style-none zpimage-space-none" data-lightbox="true" size="custom" src="/wap_1.png"/>
+                </picture>
+               </span>
+              </figure>
+             </div>
+            </div>
+           </div>
+          </div>
+          <div class="zpelement zpelem-spacer" data-element-id="elm_pZzxD-vVQjSb5KCLC2joUw" data-element-type="spacer">
+           <style>
+            div[data-element-id="elm_pZzxD-vVQjSb5KCLC2joUw"] div.zpspacer { height:14px; } @media (max-width: 768px) { div[data-element-id="elm_pZzxD-vVQjSb5KCLC2joUw"] div.zpspacer { height:calc(14px / 3); } }
+           </style>
+           <div class="zpspacer" data-height="14">
+           </div>
+          </div>
+         </div>
+        </div>
+       </div>
+      </div>
+      <div class="zpsection zpdefault-section zpdefault-section-bg" data-element-id="elm_ndh960jOKYM_Nbbo8C636Q" data-element-type="section">
+       <style type="text/css">
+        [data-element-id="elm_ndh960jOKYM_Nbbo8C636Q"].zpsection{ padding-block-start:1px; padding-block-end:42px; }
+       </style>
+       <div class="zpcontainer-fluid zpcontainer">
+        <div class="zprow zprow-container zpalign-items-flex-start zpjustify-content-flex-start zpdefault-section zpdefault-section-bg" data-element-id="elm_JX8xpX5lRDLPWQhkDrZZIw" data-element-type="row" data-equal-column="false">
+         <style type="text/css">
+         </style>
+         <div class="zpelem-col zpcol-12 zpcol-md-12 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg" data-element-id="elm_Ri0FlX6x2oAMUv7obbpDHw" data-element-type="column">
+          <style type="text/css">
+          </style>
+          <div class="zpelement zpelem-heading" data-element-id="elm_DTUcSFsLnuCDLnH5rGg8Yw" data-element-type="heading">
+           <style>
+           </style>
+           <h2 class="zpheading zpheading-style-none zpheading-align-left zpheading-align-mobile-left zpheading-align-tablet-left" data-editor="true">
+            <span style="font-size:24px;">
+             Access a Robust and Secure Wireless Security Protocol
+            </span>
+           </h2>
+          </div>
+          <div class="zpelement zpelem-accordion" data-element-id="elm_G8-7PscJ2yluVb4eJBuEEg" data-element-type="accordion" data-icon-style="4" data-tabs-inactive="true">
+           <style>
+            [data-element-id="elm_G8-7PscJ2yluVb4eJBuEEg"] .zpaccordion-container.zpaccordion-style-01 .zpaccordion, [data-element-id="elm_G8-7PscJ2yluVb4eJBuEEg"] .zpaccordion-container.zpaccordion-style-01 .zpaccordion-content{ border-style:solid; border-color: !important; } [data-element-id="elm_G8-7PscJ2yluVb4eJBuEEg"] .zpaccordion-container.zpaccordion-style-01 .zpaccordion-content.zpaccordion-active-content:last-of-type{ border-block-end-width:1px !important; } [data-element-id="elm_G8-7PscJ2yluVb4eJBuEEg"] .zpaccordion-container.zpaccordion-style-01 .zpaccordion.zpaccordion-active + .zpaccordion-content{ border-block-start-color: transparent !important; } @media all and (min-width: 768px) and (max-width:991px){ [data-element-id="elm_G8-7PscJ2yluVb4eJBuEEg"] .zpaccordion-container.zpaccordion-style-01 .zpaccordion, [data-element-id="elm_G8-7PscJ2yluVb4eJBuEEg"] .zpaccordion-container.zpaccordion-style-01 .zpaccordion-content{ border-style:solid; border-color: !important; } [data-element-id="elm_G8-7PscJ2yluVb4eJBuEEg"] .zpaccordion-container.zpaccordion-style-01 .zpaccordion-content:last-of-type{ border-block-end-width:1px !important; } [data-element-id="elm_G8-7PscJ2yluVb4eJBuEEg"] .zpaccordion-container.zpaccordion-style-01 .zpaccordion.zpaccordion-active + .zpaccordion-content{ border-block-start-color: transparent !important; } } @media all and (max-width:767px){ [data-element-id="elm_G8-7PscJ2yluVb4eJBuEEg"] .zpaccordion-container.zpaccordion-style-01 .zpaccordion, [data-element-id="elm_G8-7PscJ2yluVb4eJBuEEg"] .zpaccordion-container.zpaccordion-style-01 .zpaccordion-content{ border-style:solid; border-color: !important; } [data-element-id="elm_G8-7PscJ2yluVb4eJBuEEg"] .zpaccordion-container.zpaccordion-style-01 .zpaccordion-content:last-of-type{ border-block-end-width:1px !important; } [data-element-id="elm_G8-7PscJ2yluVb4eJBuEEg"] .zpaccordion-container.zpaccordion-style-01 .zpaccordion.zpaccordion-active + .zpaccordion-content{ border-block-start-color: transparent !important; } }
+           </style>
+           <div class="zpaccordion-container zpaccordion-style-01 zpaccordion-with-icon zpaccord-svg-icon-4 zpaccordion-icon-align-left">
+            <div aria-label="What is WPA Enterprise Level Security?" class="zpelement zpaccordion" data-content-id="elm_83IrP4v9xihlitbCBsvqYQ" data-element-id="elm_MOkuup_yiil3ka_Gmfc2DA" data-element-type="accordionheader" data-tab-name="What is WPA Enterprise Level Security?" role="button" style="margin-top:0;" tabindex="0">
+             <span class="zpaccordion-name">
+              What is WPA Enterprise Level Security?
+             </span>
+             <span class="zpaccordionicon zpaccord-icon-inactive">
+              <svg aria-hidden="true" class="svg-icon-15px zpaccord-svg-icon-1" viewbox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+               <path d="M98.9,184.7l1.8,2.1l136,156.5c4.6,5.3,11.5,8.6,19.2,8.6c7.7,0,14.6-3.4,19.2-8.6L411,187.1l2.3-2.6 c1.7-2.5,2.7-5.5,2.7-8.7c0-8.7-7.4-15.8-16.6-15.8v0H112.6v0c-9.2,0-16.6,7.1-16.6,15.8C96,179.1,97.1,182.2,98.9,184.7z">
+               </path>
+              </svg>
+              <svg aria-hidden="true" class="svg-icon-15px zpaccord-svg-icon-2" viewbox="0 0 256 256" xmlns="http://www.w3.org/2000/svg">
+               <path d="M128,169.174c-1.637,0-3.276-0.625-4.525-1.875l-56.747-56.747c-2.5-2.499-2.5-6.552,0-9.05c2.497-2.5,6.553-2.5,9.05,0 L128,153.722l52.223-52.22c2.496-2.5,6.553-2.5,9.049,0c2.5,2.499,2.5,6.552,0,9.05l-56.746,56.747 C131.277,168.549,129.638,169.174,128,169.174z M256,128C256,57.42,198.58,0,128,0C57.42,0,0,57.42,0,128c0,70.58,57.42,128,128,128 C198.58,256,256,198.58,256,128z M243.2,128c0,63.521-51.679,115.2-115.2,115.2c-63.522,0-115.2-51.679-115.2-115.2 C12.8,64.478,64.478,12.8,128,12.8C191.521,12.8,243.2,64.478,243.2,128z">
+               </path>
+              </svg>
+              <svg aria-hidden="true" class="svg-icon-15px zpaccord-svg-icon-3" viewbox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+               <path d="M256,298.3L256,298.3L256,298.3l174.2-167.2c4.3-4.2,11.4-4.1,15.8,0.2l30.6,29.9c4.4,4.3,4.5,11.3,0.2,15.5L264.1,380.9c-2.2,2.2-5.2,3.2-8.1,3c-3,0.1-5.9-0.9-8.1-3L35.2,176.7c-4.3-4.2-4.2-11.2,0.2-15.5L66,131.3c4.4-4.3,11.5-4.4,15.8-0.2L256,298.3z">
+               </path>
+              </svg>
+              <svg aria-hidden="true" class="svg-icon-15px zpaccord-svg-icon-4" viewbox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+               <path d="M417.4,224H288V94.6c0-16.9-14.3-30.6-32-30.6c-17.7,0-32,13.7-32,30.6V224H94.6C77.7,224,64,238.3,64,256 c0,17.7,13.7,32,30.6,32H224v129.4c0,16.9,14.3,30.6,32,30.6c17.7,0,32-13.7,32-30.6V288h129.4c16.9,0,30.6-14.3,30.6-32 C448,238.3,434.3,224,417.4,224z">
+               </path>
+              </svg>
+             </span>
+             <span class="zpaccordionicon zpaccord-icon-active">
+              <svg aria-hidden="true" class="svg-icon-15px zpaccord-svg-icon-1" viewbox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+               <path d="M413.1,327.3l-1.8-2.1l-136-156.5c-4.6-5.3-11.5-8.6-19.2-8.6c-7.7,0-14.6,3.4-19.2,8.6L101,324.9l-2.3,2.6 C97,330,96,333,96,336.2c0,8.7,7.4,15.8,16.6,15.8v0h286.8v0c9.2,0,16.6-7.1,16.6-15.8C416,332.9,414.9,329.8,413.1,327.3z">
+               </path>
+              </svg>
+              <svg aria-hidden="true" class="svg-icon-15px zpaccord-svg-icon-2" viewbox="0 0 256 256" xmlns="http://www.w3.org/2000/svg">
+               <path d="M184.746,156.373c-1.639,0-3.275-0.625-4.525-1.875L128,102.278l-52.223,52.22c-2.497,2.5-6.55,2.5-9.05,0 c-2.5-2.498-2.5-6.551,0-9.05l56.749-56.747c1.2-1.2,2.828-1.875,4.525-1.875l0,0c1.697,0,3.325,0.675,4.525,1.875l56.745,56.747 c2.5,2.499,2.5,6.552,0,9.05C188.021,155.748,186.383,156.373,184.746,156.373z M256,128C256,57.42,198.58,0,128,0 C57.42,0,0,57.42,0,128c0,70.58,57.42,128,128,128C198.58,256,256,198.58,256,128z M243.2,128c0,63.521-51.679,115.2-115.2,115.2 c-63.522,0-115.2-51.679-115.2-115.2C12.8,64.478,64.478,12.8,128,12.8C191.521,12.8,243.2,64.478,243.2,128z">
+               </path>
+              </svg>
+              <svg aria-hidden="true" class="svg-icon-15px zpaccord-svg-icon-3" viewbox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+               <path d="M256,213.7L256,213.7L256,213.7l174.2,167.2c4.3,4.2,11.4,4.1,15.8-0.2l30.6-29.9c4.4-4.3,4.5-11.3,0.2-15.5L264.1,131.1c-2.2-2.2-5.2-3.2-8.1-3c-3-0.1-5.9,0.9-8.1,3L35.2,335.3c-4.3,4.2-4.2,11.2,0.2,15.5L66,380.7c4.4,4.3,11.5,4.4,15.8,0.2L256,213.7z">
+               </path>
+              </svg>
+              <svg aria-hidden="true" class="svg-icon-15px zpaccord-svg-icon-4" viewbox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+               <path d="M417.4,224H94.6C77.7,224,64,238.3,64,256c0,17.7,13.7,32,30.6,32h322.8c16.9,0,30.6-14.3,30.6-32 C448,238.3,434.3,224,417.4,224z">
+               </path>
+              </svg>
+             </span>
+            </div>
+            <div class="zpelement zpaccordion-content" data-element-id="elm_83IrP4v9xihlitbCBsvqYQ" data-element-type="accordioncontainer" style="margin-top:0;">
+             <div class="zpaccordion-element-container">
+              <div class="zprow zprow-container zpalign-items-flex-start zpjustify-content-flex-start zpdefault-section zpdefault-section-bg" data-element-id="elm_dhaKm-ySoDjKWaFn1rjmDQ" data-element-type="row" data-equal-column="false">
+               <style type="text/css">
+               </style>
+               <div class="zpelem-col zpcol-12 zpcol-md-12 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg" data-element-id="elm_DpCOjfU3rKfBbUwen97n7Q" data-element-type="column">
+                <style type="text/css">
+                </style>
+                <div class="zpelement zpelem-text" data-element-id="elm_k2n6jcvwWZ3PCl_NV1NvnQ" data-element-type="text">
+                 <style>
+                 </style>
+                 <div class="zptext zptext-align-left zptext-align-mobile-left zptext-align-tablet-left" data-editor="true">
+                  <div style="color:inherit;">
+                   <div>
+                    WPA Enterprise is a Wi-Fi security protocol that provides enterprise-level security for wireless networks. It is an improvement over the more common WPA-PSK (Pre-Shared Key) protocol, which is used for home and small office networks.
+                   </div>
+                   <div>
+                    <p>
+                     The main difference between WPA-PSK and WPA Enterprise is the authentication method used. WPA-PSK uses a single shared password for all users to authenticate themselves to the network, while WPA Enterprise uses a more robust authentication method that involves a RADIUS (Remote Authentication Dial-In User Service) server.
+                    </p>
+                    <p>
+                     In WPA Enterprise, each user is assigned their own unique username and password, which they use to authenticate themselves to the network. The RADIUS server acts as a central authentication server, verifying each user's credentials before allowing them to access the network. This provides a higher level of security, as it ensures that only authorized users can access the network.
+                    </p>
+                    <p>
+                     WPA Enterprise also supports additional security features, such as 802.1X port-based access control, which allows administrators to control access to specific ports on the network based on a user's authentication status. This can help prevent unauthorized access and protect against attacks such as port scanning.
+                    </p>
+                    <p>
+                     Overall, WPA Enterprise provides a higher level of security than WPA-PSK, making it a better choice for enterprise-level wireless networks where security is a top priority. However, implementing WPA Enterprise requires additional infrastructure and expertise, as it involves setting up a RADIUS server and configuring network devices to support 802.1X authentication.
+                    </p>
+                   </div>
+                  </div>
+                 </div>
+                </div>
+               </div>
+              </div>
+             </div>
+            </div>
+            <div aria-label="Why is WPA Enterprise Level Security Important?" class="zpelement zpaccordion" data-content-id="elm_952LoFb1dsy9ogYvxW1ZZg" data-element-id="elm_inHJgM1In7xJK_skIqkm3w" data-element-type="accordionheader" data-tab-name="Why is WPA Enterprise Level Security Important?" role="button" style="margin-top:0;" tabindex="0">
+             <span class="zpaccordion-name">
+              Why is WPA Enterprise Level Security Important?
+             </span>
+             <span class="zpaccordionicon zpaccord-icon-inactive">
+              <svg aria-hidden="true" class="svg-icon-15px zpaccord-svg-icon-1" viewbox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+               <path d="M98.9,184.7l1.8,2.1l136,156.5c4.6,5.3,11.5,8.6,19.2,8.6c7.7,0,14.6-3.4,19.2-8.6L411,187.1l2.3-2.6 c1.7-2.5,2.7-5.5,2.7-8.7c0-8.7-7.4-15.8-16.6-15.8v0H112.6v0c-9.2,0-16.6,7.1-16.6,15.8C96,179.1,97.1,182.2,98.9,184.7z">
+               </path>
+              </svg>
+              <svg aria-hidden="true" class="svg-icon-15px zpaccord-svg-icon-2" viewbox="0 0 256 256" xmlns="http://www.w3.org/2000/svg">
+               <path d="M128,169.174c-1.637,0-3.276-0.625-4.525-1.875l-56.747-56.747c-2.5-2.499-2.5-6.552,0-9.05c2.497-2.5,6.553-2.5,9.05,0 L128,153.722l52.223-52.22c2.496-2.5,6.553-2.5,9.049,0c2.5,2.499,2.5,6.552,0,9.05l-56.746,56.747 C131.277,168.549,129.638,169.174,128,169.174z M256,128C256,57.42,198.58,0,128,0C57.42,0,0,57.42,0,128c0,70.58,57.42,128,128,128 C198.58,256,256,198.58,256,128z M243.2,128c0,63.521-51.679,115.2-115.2,115.2c-63.522,0-115.2-51.679-115.2-115.2 C12.8,64.478,64.478,12.8,128,12.8C191.521,12.8,243.2,64.478,243.2,128z">
+               </path>
+              </svg>
+              <svg aria-hidden="true" class="svg-icon-15px zpaccord-svg-icon-3" viewbox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+               <path d="M256,298.3L256,298.3L256,298.3l174.2-167.2c4.3-4.2,11.4-4.1,15.8,0.2l30.6,29.9c4.4,4.3,4.5,11.3,0.2,15.5L264.1,380.9c-2.2,2.2-5.2,3.2-8.1,3c-3,0.1-5.9-0.9-8.1-3L35.2,176.7c-4.3-4.2-4.2-11.2,0.2-15.5L66,131.3c4.4-4.3,11.5-4.4,15.8-0.2L256,298.3z">
+               </path>
+              </svg>
+              <svg aria-hidden="true" class="svg-icon-15px zpaccord-svg-icon-4" viewbox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+               <path d="M417.4,224H288V94.6c0-16.9-14.3-30.6-32-30.6c-17.7,0-32,13.7-32,30.6V224H94.6C77.7,224,64,238.3,64,256 c0,17.7,13.7,32,30.6,32H224v129.4c0,16.9,14.3,30.6,32,30.6c17.7,0,32-13.7,32-30.6V288h129.4c16.9,0,30.6-14.3,30.6-32 C448,238.3,434.3,224,417.4,224z">
+               </path>
+              </svg>
+             </span>
+             <span class="zpaccordionicon zpaccord-icon-active">
+              <svg aria-hidden="true" class="svg-icon-15px zpaccord-svg-icon-1" viewbox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+               <path d="M413.1,327.3l-1.8-2.1l-136-156.5c-4.6-5.3-11.5-8.6-19.2-8.6c-7.7,0-14.6,3.4-19.2,8.6L101,324.9l-2.3,2.6 C97,330,96,333,96,336.2c0,8.7,7.4,15.8,16.6,15.8v0h286.8v0c9.2,0,16.6-7.1,16.6-15.8C416,332.9,414.9,329.8,413.1,327.3z">
+               </path>
+              </svg>
+              <svg aria-hidden="true" class="svg-icon-15px zpaccord-svg-icon-2" viewbox="0 0 256 256" xmlns="http://www.w3.org/2000/svg">
+               <path d="M184.746,156.373c-1.639,0-3.275-0.625-4.525-1.875L128,102.278l-52.223,52.22c-2.497,2.5-6.55,2.5-9.05,0 c-2.5-2.498-2.5-6.551,0-9.05l56.749-56.747c1.2-1.2,2.828-1.875,4.525-1.875l0,0c1.697,0,3.325,0.675,4.525,1.875l56.745,56.747 c2.5,2.499,2.5,6.552,0,9.05C188.021,155.748,186.383,156.373,184.746,156.373z M256,128C256,57.42,198.58,0,128,0 C57.42,0,0,57.42,0,128c0,70.58,57.42,128,128,128C198.58,256,256,198.58,256,128z M243.2,128c0,63.521-51.679,115.2-115.2,115.2 c-63.522,0-115.2-51.679-115.2-115.2C12.8,64.478,64.478,12.8,128,12.8C191.521,12.8,243.2,64.478,243.2,128z">
+               </path>
+              </svg>
+              <svg aria-hidden="true" class="svg-icon-15px zpaccord-svg-icon-3" viewbox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+               <path d="M256,213.7L256,213.7L256,213.7l174.2,167.2c4.3,4.2,11.4,4.1,15.8-0.2l30.6-29.9c4.4-4.3,4.5-11.3,0.2-15.5L264.1,131.1c-2.2-2.2-5.2-3.2-8.1-3c-3-0.1-5.9,0.9-8.1,3L35.2,335.3c-4.3,4.2-4.2,11.2,0.2,15.5L66,380.7c4.4,4.3,11.5,4.4,15.8,0.2L256,213.7z">
+               </path>
+              </svg>
+              <svg aria-hidden="true" class="svg-icon-15px zpaccord-svg-icon-4" viewbox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+               <path d="M417.4,224H94.6C77.7,224,64,238.3,64,256c0,17.7,13.7,32,30.6,32h322.8c16.9,0,30.6-14.3,30.6-32 C448,238.3,434.3,224,417.4,224z">
+               </path>
+              </svg>
+             </span>
+            </div>
+            <div class="zpelement zpaccordion-content" data-element-id="elm_952LoFb1dsy9ogYvxW1ZZg" data-element-type="accordioncontainer" style="margin-top:0;">
+             <div class="zpaccordion-element-container">
+              <div class="zprow zprow-container zpalign-items-flex-start zpjustify-content-flex-start zpdefault-section zpdefault-section-bg" data-element-id="elm_LG7Ls2JALHYjW60E1SNzzg" data-element-type="row" data-equal-column="false">
+               <style type="text/css">
+               </style>
+               <div class="zpelem-col zpcol-12 zpcol-md-12 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg" data-element-id="elm_gw5jF3J8PVGynydB_ITmWA" data-element-type="column">
+                <style type="text/css">
+                </style>
+                <div class="zpelement zpelem-text" data-element-id="elm_lSFtpNrY7MkvMSTRMTjZDw" data-element-type="text">
+                 <style>
+                 </style>
+                 <div class="zptext zptext-align-left zptext-align-mobile-left zptext-align-tablet-left" data-editor="true">
+                  <div style="color:inherit;">
+                   <p>
+                    WPA Enterprise level security is important because it provides a higher level of security than other Wi-Fi security protocols, especially for enterprise-level wireless networks. Here are some reasons why WPA Enterprise level security is important:
+                   </p>
+                   <ol>
+                    <li>
+                     <p>
+                      Stronger authentication: WPA Enterprise uses a more robust authentication method that involves a RADIUS server, which provides each user with a unique username and password. This makes it more difficult for attackers to gain unauthorized access to the network.
+                     </p>
+                    </li>
+                    <li>
+                     <p>
+                      Individualized access control: Each user's credentials are verified by the RADIUS server, which ensures that only authorized users can access the network. This allows for more granular access control and helps prevent unauthorized access to the network.
+                     </p>
+                    </li>
+                    <li>
+                     <p>
+                      Better protection against attacks: WPA Enterprise supports additional security features, such as 802.1X port-based access control, which can help protect against attacks such as port scanning and other types of network-based attacks.
+                     </p>
+                    </li>
+                    <li>
+                     <p>
+                      Compliance: In many industries, such as finance, healthcare, and government, there are regulations that require the use of stronger security protocols for wireless networks. WPA Enterprise helps ensure compliance with these regulations.
+                     </p>
+                    </li>
+                    <li>
+                     <p>
+                      Reputation: A security breach can damage a business's reputation and erode customer trust. By implementing WPA Enterprise level security, businesses can demonstrate their commitment to security and protect their reputation.
+                     </p>
+                    </li>
+                   </ol>
+                   <p>
+                    Overall, WPA Enterprise level security is important because it provides a higher level of security for wireless networks, especially for enterprise-level networks where security is a top priority. By implementing WPA Enterprise level security, businesses can protect their networks, their customers, and their reputation.
+                   </p>
+                  </div>
+                 </div>
+                </div>
+               </div>
+              </div>
+             </div>
+            </div>
+            <div aria-label="How Can IronWiFi's WPA Enterprise Security Help My Business?" class="zpelement zpaccordion" data-content-id="elm_0_SRHVETb-bu69Ax7W6BqA" data-element-id="elm_iHnXP4JN2dOU385ocJvV2Q" data-element-type="accordionheader" data-tab-name="How Can IronWiFi's WPA Enterprise Security Help My Business?" role="button" style="margin-top:0;" tabindex="0">
+             <span class="zpaccordion-name">
+              How Can IronWiFi's WPA Enterprise Security Help My Business?
+             </span>
+             <span class="zpaccordionicon zpaccord-icon-inactive">
+              <svg aria-hidden="true" class="svg-icon-15px zpaccord-svg-icon-1" viewbox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+               <path d="M98.9,184.7l1.8,2.1l136,156.5c4.6,5.3,11.5,8.6,19.2,8.6c7.7,0,14.6-3.4,19.2-8.6L411,187.1l2.3-2.6 c1.7-2.5,2.7-5.5,2.7-8.7c0-8.7-7.4-15.8-16.6-15.8v0H112.6v0c-9.2,0-16.6,7.1-16.6,15.8C96,179.1,97.1,182.2,98.9,184.7z">
+               </path>
+              </svg>
+              <svg aria-hidden="true" class="svg-icon-15px zpaccord-svg-icon-2" viewbox="0 0 256 256" xmlns="http://www.w3.org/2000/svg">
+               <path d="M128,169.174c-1.637,0-3.276-0.625-4.525-1.875l-56.747-56.747c-2.5-2.499-2.5-6.552,0-9.05c2.497-2.5,6.553-2.5,9.05,0 L128,153.722l52.223-52.22c2.496-2.5,6.553-2.5,9.049,0c2.5,2.499,2.5,6.552,0,9.05l-56.746,56.747 C131.277,168.549,129.638,169.174,128,169.174z M256,128C256,57.42,198.58,0,128,0C57.42,0,0,57.42,0,128c0,70.58,57.42,128,128,128 C198.58,256,256,198.58,256,128z M243.2,128c0,63.521-51.679,115.2-115.2,115.2c-63.522,0-115.2-51.679-115.2-115.2 C12.8,64.478,64.478,12.8,128,12.8C191.521,12.8,243.2,64.478,243.2,128z">
+               </path>
+              </svg>
+              <svg aria-hidden="true" class="svg-icon-15px zpaccord-svg-icon-3" viewbox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+               <path d="M256,298.3L256,298.3L256,298.3l174.2-167.2c4.3-4.2,11.4-4.1,15.8,0.2l30.6,29.9c4.4,4.3,4.5,11.3,0.2,15.5L264.1,380.9c-2.2,2.2-5.2,3.2-8.1,3c-3,0.1-5.9-0.9-8.1-3L35.2,176.7c-4.3-4.2-4.2-11.2,0.2-15.5L66,131.3c4.4-4.3,11.5-4.4,15.8-0.2L256,298.3z">
+               </path>
+              </svg>
+              <svg aria-hidden="true" class="svg-icon-15px zpaccord-svg-icon-4" viewbox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+               <path d="M417.4,224H288V94.6c0-16.9-14.3-30.6-32-30.6c-17.7,0-32,13.7-32,30.6V224H94.6C77.7,224,64,238.3,64,256 c0,17.7,13.7,32,30.6,32H224v129.4c0,16.9,14.3,30.6,32,30.6c17.7,0,32-13.7,32-30.6V288h129.4c16.9,0,30.6-14.3,30.6-32 C448,238.3,434.3,224,417.4,224z">
+               </path>
+              </svg>
+             </span>
+             <span class="zpaccordionicon zpaccord-icon-active">
+              <svg aria-hidden="true" class="svg-icon-15px zpaccord-svg-icon-1" viewbox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+               <path d="M413.1,327.3l-1.8-2.1l-136-156.5c-4.6-5.3-11.5-8.6-19.2-8.6c-7.7,0-14.6,3.4-19.2,8.6L101,324.9l-2.3,2.6 C97,330,96,333,96,336.2c0,8.7,7.4,15.8,16.6,15.8v0h286.8v0c9.2,0,16.6-7.1,16.6-15.8C416,332.9,414.9,329.8,413.1,327.3z">
+               </path>
+              </svg>
+              <svg aria-hidden="true" class="svg-icon-15px zpaccord-svg-icon-2" viewbox="0 0 256 256" xmlns="http://www.w3.org/2000/svg">
+               <path d="M184.746,156.373c-1.639,0-3.275-0.625-4.525-1.875L128,102.278l-52.223,52.22c-2.497,2.5-6.55,2.5-9.05,0 c-2.5-2.498-2.5-6.551,0-9.05l56.749-56.747c1.2-1.2,2.828-1.875,4.525-1.875l0,0c1.697,0,3.325,0.675,4.525,1.875l56.745,56.747 c2.5,2.499,2.5,6.552,0,9.05C188.021,155.748,186.383,156.373,184.746,156.373z M256,128C256,57.42,198.58,0,128,0 C57.42,0,0,57.42,0,128c0,70.58,57.42,128,128,128C198.58,256,256,198.58,256,128z M243.2,128c0,63.521-51.679,115.2-115.2,115.2 c-63.522,0-115.2-51.679-115.2-115.2C12.8,64.478,64.478,12.8,128,12.8C191.521,12.8,243.2,64.478,243.2,128z">
+               </path>
+              </svg>
+              <svg aria-hidden="true" class="svg-icon-15px zpaccord-svg-icon-3" viewbox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+               <path d="M256,213.7L256,213.7L256,213.7l174.2,167.2c4.3,4.2,11.4,4.1,15.8-0.2l30.6-29.9c4.4-4.3,4.5-11.3,0.2-15.5L264.1,131.1c-2.2-2.2-5.2-3.2-8.1-3c-3-0.1-5.9,0.9-8.1,3L35.2,335.3c-4.3,4.2-4.2,11.2,0.2,15.5L66,380.7c4.4,4.3,11.5,4.4,15.8,0.2L256,213.7z">
+               </path>
+              </svg>
+              <svg aria-hidden="true" class="svg-icon-15px zpaccord-svg-icon-4" viewbox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+               <path d="M417.4,224H94.6C77.7,224,64,238.3,64,256c0,17.7,13.7,32,30.6,32h322.8c16.9,0,30.6-14.3,30.6-32 C448,238.3,434.3,224,417.4,224z">
+               </path>
+              </svg>
+             </span>
+            </div>
+            <div class="zpelement zpaccordion-content" data-element-id="elm_0_SRHVETb-bu69Ax7W6BqA" data-element-type="accordioncontainer" style="margin-top:0;">
+             <div class="zpaccordion-element-container">
+              <div class="zprow zprow-container zpalign-items-flex-start zpjustify-content-flex-start zpdefault-section zpdefault-section-bg" data-element-id="elm_52hftUGY5bTiZs683TEhew" data-element-type="row" data-equal-column="false">
+               <style type="text/css">
+               </style>
+               <div class="zpelem-col zpcol-12 zpcol-md-12 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg" data-element-id="elm_cB7VlAt43YfMPuu26D3dfA" data-element-type="column">
+                <style type="text/css">
+                </style>
+                <div class="zpelement zpelem-text" data-element-id="elm_vwbMZYSz98L03YxheTOScQ" data-element-type="text">
+                 <style>
+                 </style>
+                 <div class="zptext zptext-align-left zptext-align-mobile-left zptext-align-tablet-left" data-editor="true">
+                  <div style="color:inherit;">
+                   <p>
+                    IronWiFi's WPA Enterprise level security helps businesses in several ways:
+                   </p>
+                   <ol>
+                    <li>
+                     <p>
+                      Strong authentication: WPA Enterprise provides strong authentication through the use of digital certificates, which helps to prevent unauthorized access to the network. This ensures that only authorized users can connect to the network, and helps to protect against security threats such as hacking, eavesdropping, and man-in-the-middle attacks.
+                     </p>
+                    </li>
+                    <li>
+                     <p>
+                      Centralized management: WPA Enterprise provides centralized management of network access, which makes it easy for businesses to control who has access to the network and to enforce security policies. This reduces the burden on IT staff and helps to ensure that security policies are consistently applied across the network.
+                     </p>
+                    </li>
+                    <li>
+                     <p>
+                      Scalability: WPA Enterprise is highly scalable, making it well-suited for large businesses with many users and devices. The system can easily accommodate new users and devices, and can be integrated with existing IT infrastructure.
+                     </p>
+                    </li>
+                    <li>
+                     <p>
+                      Compliance: Many industries have specific security and privacy regulations that businesses must comply with, such as HIPAA in healthcare and PCI-DSS in the payment card industry. WPA Enterprise can help businesses meet these requirements by providing strong security controls and audit trails.
+                     </p>
+                    </li>
+                    <li>
+                     <p>
+                      Improved productivity: By providing a secure and reliable network, WPA Enterprise can help to improve productivity and reduce downtime. This can have a positive impact on the bottom line of businesses, especially those that rely heavily on their IT systems.
+                     </p>
+                    </li>
+                   </ol>
+                   <p>
+                    Overall, IronWiFi's WPA Enterprise level security can help businesses by providing strong authentication, centralized management, scalability, compliance with regulations, and improved productivity.
+                   </p>
+                  </div>
+                 </div>
+                </div>
+               </div>
+              </div>
+             </div>
+            </div>
+            <div aria-label=" Distribution of Security Certificates" class="zpelement zpaccordion" data-content-id="elm_FMQv2s44Rit3KOuD2KVAPg" data-element-id="elm_AUNqAUWt6GzqEurctgGp9w" data-element-type="accordionheader" data-tab-name=" Distribution of Security Certificates" role="button" style="margin-top:0;" tabindex="0">
+             <span class="zpaccordion-name">
+              Distribution of Security Certificates
+             </span>
+             <span class="zpaccordionicon zpaccord-icon-inactive">
+              <svg aria-hidden="true" class="svg-icon-15px zpaccord-svg-icon-1" viewbox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+               <path d="M98.9,184.7l1.8,2.1l136,156.5c4.6,5.3,11.5,8.6,19.2,8.6c7.7,0,14.6-3.4,19.2-8.6L411,187.1l2.3-2.6 c1.7-2.5,2.7-5.5,2.7-8.7c0-8.7-7.4-15.8-16.6-15.8v0H112.6v0c-9.2,0-16.6,7.1-16.6,15.8C96,179.1,97.1,182.2,98.9,184.7z">
+               </path>
+              </svg>
+              <svg aria-hidden="true" class="svg-icon-15px zpaccord-svg-icon-2" viewbox="0 0 256 256" xmlns="http://www.w3.org/2000/svg">
+               <path d="M128,169.174c-1.637,0-3.276-0.625-4.525-1.875l-56.747-56.747c-2.5-2.499-2.5-6.552,0-9.05c2.497-2.5,6.553-2.5,9.05,0 L128,153.722l52.223-52.22c2.496-2.5,6.553-2.5,9.049,0c2.5,2.499,2.5,6.552,0,9.05l-56.746,56.747 C131.277,168.549,129.638,169.174,128,169.174z M256,128C256,57.42,198.58,0,128,0C57.42,0,0,57.42,0,128c0,70.58,57.42,128,128,128 C198.58,256,256,198.58,256,128z M243.2,128c0,63.521-51.679,115.2-115.2,115.2c-63.522,0-115.2-51.679-115.2-115.2 C12.8,64.478,64.478,12.8,128,12.8C191.521,12.8,243.2,64.478,243.2,128z">
+               </path>
+              </svg>
+              <svg aria-hidden="true" class="svg-icon-15px zpaccord-svg-icon-3" viewbox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+               <path d="M256,298.3L256,298.3L256,298.3l174.2-167.2c4.3-4.2,11.4-4.1,15.8,0.2l30.6,29.9c4.4,4.3,4.5,11.3,0.2,15.5L264.1,380.9c-2.2,2.2-5.2,3.2-8.1,3c-3,0.1-5.9-0.9-8.1-3L35.2,176.7c-4.3-4.2-4.2-11.2,0.2-15.5L66,131.3c4.4-4.3,11.5-4.4,15.8-0.2L256,298.3z">
+               </path>
+              </svg>
+              <svg aria-hidden="true" class="svg-icon-15px zpaccord-svg-icon-4" viewbox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+               <path d="M417.4,224H288V94.6c0-16.9-14.3-30.6-32-30.6c-17.7,0-32,13.7-32,30.6V224H94.6C77.7,224,64,238.3,64,256 c0,17.7,13.7,32,30.6,32H224v129.4c0,16.9,14.3,30.6,32,30.6c17.7,0,32-13.7,32-30.6V288h129.4c16.9,0,30.6-14.3,30.6-32 C448,238.3,434.3,224,417.4,224z">
+               </path>
+              </svg>
+             </span>
+             <span class="zpaccordionicon zpaccord-icon-active">
+              <svg aria-hidden="true" class="svg-icon-15px zpaccord-svg-icon-1" viewbox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+               <path d="M413.1,327.3l-1.8-2.1l-136-156.5c-4.6-5.3-11.5-8.6-19.2-8.6c-7.7,0-14.6,3.4-19.2,8.6L101,324.9l-2.3,2.6 C97,330,96,333,96,336.2c0,8.7,7.4,15.8,16.6,15.8v0h286.8v0c9.2,0,16.6-7.1,16.6-15.8C416,332.9,414.9,329.8,413.1,327.3z">
+               </path>
+              </svg>
+              <svg aria-hidden="true" class="svg-icon-15px zpaccord-svg-icon-2" viewbox="0 0 256 256" xmlns="http://www.w3.org/2000/svg">
+               <path d="M184.746,156.373c-1.639,0-3.275-0.625-4.525-1.875L128,102.278l-52.223,52.22c-2.497,2.5-6.55,2.5-9.05,0 c-2.5-2.498-2.5-6.551,0-9.05l56.749-56.747c1.2-1.2,2.828-1.875,4.525-1.875l0,0c1.697,0,3.325,0.675,4.525,1.875l56.745,56.747 c2.5,2.499,2.5,6.552,0,9.05C188.021,155.748,186.383,156.373,184.746,156.373z M256,128C256,57.42,198.58,0,128,0 C57.42,0,0,57.42,0,128c0,70.58,57.42,128,128,128C198.58,256,256,198.58,256,128z M243.2,128c0,63.521-51.679,115.2-115.2,115.2 c-63.522,0-115.2-51.679-115.2-115.2C12.8,64.478,64.478,12.8,128,12.8C191.521,12.8,243.2,64.478,243.2,128z">
+               </path>
+              </svg>
+              <svg aria-hidden="true" class="svg-icon-15px zpaccord-svg-icon-3" viewbox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+               <path d="M256,213.7L256,213.7L256,213.7l174.2,167.2c4.3,4.2,11.4,4.1,15.8-0.2l30.6-29.9c4.4-4.3,4.5-11.3,0.2-15.5L264.1,131.1c-2.2-2.2-5.2-3.2-8.1-3c-3-0.1-5.9,0.9-8.1,3L35.2,335.3c-4.3,4.2-4.2,11.2,0.2,15.5L66,380.7c4.4,4.3,11.5,4.4,15.8,0.2L256,213.7z">
+               </path>
+              </svg>
+              <svg aria-hidden="true" class="svg-icon-15px zpaccord-svg-icon-4" viewbox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+               <path d="M417.4,224H94.6C77.7,224,64,238.3,64,256c0,17.7,13.7,32,30.6,32h322.8c16.9,0,30.6-14.3,30.6-32 C448,238.3,434.3,224,417.4,224z">
+               </path>
+              </svg>
+             </span>
+            </div>
+            <div class="zpelement zpaccordion-content" data-element-id="elm_FMQv2s44Rit3KOuD2KVAPg" data-element-type="accordioncontainer" style="margin-top:0;">
+             <div class="zpaccordion-element-container">
+              <div class="zprow zprow-container zpalign-items-flex-start zpjustify-content-flex-start zpdefault-section zpdefault-section-bg" data-element-id="elm_lSNOalEu8AnuiCMZaD6r3A" data-element-type="row" data-equal-column="false">
+               <style type="text/css">
+               </style>
+               <div class="zpelem-col zpcol-12 zpcol-md-12 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg" data-element-id="elm_9X43Ly5oXzCIrSWBNRk-Cw" data-element-type="column">
+                <style type="text/css">
+                </style>
+                <div class="zpelement zpelem-text" data-element-id="elm_0AMpDs8TadrbyxOAXJSreQ" data-element-type="text">
+                 <style>
+                 </style>
+                 <div class="zptext zptext-align-left zptext-align-mobile-left zptext-align-tablet-left" data-editor="true">
+                  <div style="color:inherit;">
+                   <div style="color:inherit;">
+                    <div>
+                     <div>
+                      <br/>
+                     </div>
+                     <div>
+                     </div>
+                    </div>
+                    <div>
+                     <div>
+                      <h3 style="font-size:24px;">
+                       <p>
+                        Distribution of Security Certificates
+                       </p>
+                      </h3>
+                     </div>
+                     <div>
+                      <div>
+                       <p>
+                        Security certificates need to be installed on the user’s device in order to connect to the network. Once installed, the users device will seamlessly connect to the network, removing the need for the user to enter their username and password every time they wish to connect.
+                       </p>
+                       <p>
+                        Three options are available to obtain the generated certificate:
+                       </p>
+                       <ul>
+                        <li>
+                         <span style="font-weight:700;">
+                          Download certificate
+                         </span>
+                         – the certificate will be automatically downloaded to the administrator’s browser. An import password will be displayed in the pop-up window.
+                        </li>
+                        <li>
+                         <span style="font-weight:700;">
+                          Email certificate to the user
+                         </span>
+                         – The user will obtain an email with a certificate in the attachment. An import password is included in the email. This method requires the user to have a valid email address.
+                        </li>
+                        <li>
+                         <span style="font-weight:700;">
+                          Email download link to the user
+                         </span>
+                         – an email is sent to the user with an import password and a link to download the certificate. The certificate can be downloaded only once. A valid email address in the user profile is required to deliver the email.
+                        </li>
+                       </ul>
+                       <p>
+                        OR
+                       </p>
+                       <p>
+                        use a SCEP server to issue certificates in real time.
+                       </p>
+                      </div>
+                     </div>
+                    </div>
+                   </div>
+                  </div>
+                 </div>
+                </div>
+               </div>
+              </div>
+             </div>
+            </div>
+            <div aria-label="External Identity Providers" class="zpelement zpaccordion" data-content-id="elm_XJro8jVBEkUi_BTIXvzH1g" data-element-id="elm_B7dHNhjK_vZWs8Zpu8oYew" data-element-type="accordionheader" data-tab-name="External Identity Providers" role="button" style="margin-top:0;" tabindex="0">
+             <span class="zpaccordion-name">
+              External Identity Providers
+             </span>
+             <span class="zpaccordionicon zpaccord-icon-inactive">
+              <svg aria-hidden="true" class="svg-icon-15px zpaccord-svg-icon-1" viewbox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+               <path d="M98.9,184.7l1.8,2.1l136,156.5c4.6,5.3,11.5,8.6,19.2,8.6c7.7,0,14.6-3.4,19.2-8.6L411,187.1l2.3-2.6 c1.7-2.5,2.7-5.5,2.7-8.7c0-8.7-7.4-15.8-16.6-15.8v0H112.6v0c-9.2,0-16.6,7.1-16.6,15.8C96,179.1,97.1,182.2,98.9,184.7z">
+               </path>
+              </svg>
+              <svg aria-hidden="true" class="svg-icon-15px zpaccord-svg-icon-2" viewbox="0 0 256 256" xmlns="http://www.w3.org/2000/svg">
+               <path d="M128,169.174c-1.637,0-3.276-0.625-4.525-1.875l-56.747-56.747c-2.5-2.499-2.5-6.552,0-9.05c2.497-2.5,6.553-2.5,9.05,0 L128,153.722l52.223-52.22c2.496-2.5,6.553-2.5,9.049,0c2.5,2.499,2.5,6.552,0,9.05l-56.746,56.747 C131.277,168.549,129.638,169.174,128,169.174z M256,128C256,57.42,198.58,0,128,0C57.42,0,0,57.42,0,128c0,70.58,57.42,128,128,128 C198.58,256,256,198.58,256,128z M243.2,128c0,63.521-51.679,115.2-115.2,115.2c-63.522,0-115.2-51.679-115.2-115.2 C12.8,64.478,64.478,12.8,128,12.8C191.521,12.8,243.2,64.478,243.2,128z">
+               </path>
+              </svg>
+              <svg aria-hidden="true" class="svg-icon-15px zpaccord-svg-icon-3" viewbox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+               <path d="M256,298.3L256,298.3L256,298.3l174.2-167.2c4.3-4.2,11.4-4.1,15.8,0.2l30.6,29.9c4.4,4.3,4.5,11.3,0.2,15.5L264.1,380.9c-2.2,2.2-5.2,3.2-8.1,3c-3,0.1-5.9-0.9-8.1-3L35.2,176.7c-4.3-4.2-4.2-11.2,0.2-15.5L66,131.3c4.4-4.3,11.5-4.4,15.8-0.2L256,298.3z">
+               </path>
+              </svg>
+              <svg aria-hidden="true" class="svg-icon-15px zpaccord-svg-icon-4" viewbox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+               <path d="M417.4,224H288V94.6c0-16.9-14.3-30.6-32-30.6c-17.7,0-32,13.7-32,30.6V224H94.6C77.7,224,64,238.3,64,256 c0,17.7,13.7,32,30.6,32H224v129.4c0,16.9,14.3,30.6,32,30.6c17.7,0,32-13.7,32-30.6V288h129.4c16.9,0,30.6-14.3,30.6-32 C448,238.3,434.3,224,417.4,224z">
+               </path>
+              </svg>
+             </span>
+             <span class="zpaccordionicon zpaccord-icon-active">
+              <svg aria-hidden="true" class="svg-icon-15px zpaccord-svg-icon-1" viewbox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+               <path d="M413.1,327.3l-1.8-2.1l-136-156.5c-4.6-5.3-11.5-8.6-19.2-8.6c-7.7,0-14.6,3.4-19.2,8.6L101,324.9l-2.3,2.6 C97,330,96,333,96,336.2c0,8.7,7.4,15.8,16.6,15.8v0h286.8v0c9.2,0,16.6-7.1,16.6-15.8C416,332.9,414.9,329.8,413.1,327.3z">
+               </path>
+              </svg>
+              <svg aria-hidden="true" class="svg-icon-15px zpaccord-svg-icon-2" viewbox="0 0 256 256" xmlns="http://www.w3.org/2000/svg">
+               <path d="M184.746,156.373c-1.639,0-3.275-0.625-4.525-1.875L128,102.278l-52.223,52.22c-2.497,2.5-6.55,2.5-9.05,0 c-2.5-2.498-2.5-6.551,0-9.05l56.749-56.747c1.2-1.2,2.828-1.875,4.525-1.875l0,0c1.697,0,3.325,0.675,4.525,1.875l56.745,56.747 c2.5,2.499,2.5,6.552,0,9.05C188.021,155.748,186.383,156.373,184.746,156.373z M256,128C256,57.42,198.58,0,128,0 C57.42,0,0,57.42,0,128c0,70.58,57.42,128,128,128C198.58,256,256,198.58,256,128z M243.2,128c0,63.521-51.679,115.2-115.2,115.2 c-63.522,0-115.2-51.679-115.2-115.2C12.8,64.478,64.478,12.8,128,12.8C191.521,12.8,243.2,64.478,243.2,128z">
+               </path>
+              </svg>
+              <svg aria-hidden="true" class="svg-icon-15px zpaccord-svg-icon-3" viewbox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+               <path d="M256,213.7L256,213.7L256,213.7l174.2,167.2c4.3,4.2,11.4,4.1,15.8-0.2l30.6-29.9c4.4-4.3,4.5-11.3,0.2-15.5L264.1,131.1c-2.2-2.2-5.2-3.2-8.1-3c-3-0.1-5.9,0.9-8.1,3L35.2,335.3c-4.3,4.2-4.2,11.2,0.2,15.5L66,380.7c4.4,4.3,11.5,4.4,15.8,0.2L256,213.7z">
+               </path>
+              </svg>
+              <svg aria-hidden="true" class="svg-icon-15px zpaccord-svg-icon-4" viewbox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+               <path d="M417.4,224H94.6C77.7,224,64,238.3,64,256c0,17.7,13.7,32,30.6,32h322.8c16.9,0,30.6-14.3,30.6-32 C448,238.3,434.3,224,417.4,224z">
+               </path>
+              </svg>
+             </span>
+            </div>
+            <div class="zpelement zpaccordion-content" data-element-id="elm_XJro8jVBEkUi_BTIXvzH1g" data-element-type="accordioncontainer" style="margin-top:0;">
+             <div class="zpaccordion-element-container">
+              <div class="zprow zprow-container zpalign-items-flex-start zpjustify-content-flex-start zpdefault-section zpdefault-section-bg" data-element-id="elm_cVfa1QzERmD7HTyJkzDbNw" data-element-type="row" data-equal-column="false">
+               <style type="text/css">
+               </style>
+               <div class="zpelem-col zpcol-12 zpcol-md-12 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg" data-element-id="elm_rPs6iQmZzklbrQUnbYT-9w" data-element-type="column">
+                <style type="text/css">
+                </style>
+                <div class="zpelement zpelem-text" data-element-id="elm_Flb77-ZdZZuj3ge9L61UTw" data-element-type="text">
+                 <style>
+                 </style>
+                 <div class="zptext zptext-align-left zptext-align-mobile-left zptext-align-tablet-left" data-editor="true">
+                  <p>
+                   <span style="color:inherit;">
+                    IronWiFi allows for simple integration of external identity providers. By creating a "Connector", you can import all your employees or students in one click. Real-time synchronization is what allows us to stay up to date with your active directory. A few examples of the identity providers / databases we integrate with include Azure, Google, REST API (custom), LDAP.
+                   </span>
+                  </p>
+                 </div>
+                </div>
+               </div>
+              </div>
+             </div>
+            </div>
+           </div>
+          </div>
+         </div>
+        </div>
+       </div>
+      </div>
+      <div class="zpsection zpdefault-section zpdefault-section-bg" data-element-id="elm_PGngkk8L1C7Iie8yJTP7qA" data-element-type="section">
+       <style type="text/css">
+        [data-element-id="elm_PGngkk8L1C7Iie8yJTP7qA"].zpsection{ padding-block-start:27px; }
+       </style>
+       <div class="zpcontainer-fluid zpcontainer">
+        <div class="zprow zprow-container zpalign-items-center zpjustify-content-flex-start" data-element-id="elm_FUTLmhmkZn5B-rYyOaubwA" data-element-type="row" data-equal-column="">
+         <style type="text/css">
+         </style>
+         <div class="zpelem-col zpcol-12 zpcol-md-4 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg" data-element-id="elm_WgjDS8762NEtGAnmb33XLw" data-element-type="column">
+          <style type="text/css">
+          </style>
+          <div class="zpelement zpelem-image" data-element-id="elm_7Wcx0J1VIwiGk9czqJMsqA" data-element-type="image">
+           <style>
+            @media (min-width: 992px) { [data-element-id="elm_7Wcx0J1VIwiGk9czqJMsqA"] .zpimage-container figure img { width: 318px !important ; height: 318px !important ; } } [data-element-id="elm_7Wcx0J1VIwiGk9czqJMsqA"].zpelem-image { margin-block-start:-1px; }
+           </style>
+           <div class="zpimage-container zpimage-align-center zpimage-tablet-align-center zpimage-mobile-align-center zpimage-size-custom zpimage-tablet-fallback-fit zpimage-mobile-fallback-fit hb-lightbox" data-align="center" data-caption-color="" data-lightbox-options="
                 type:fullscreen,
-                theme:dark"><figure role="none" class="zpimage-data-ref"><span class="zpimage-anchor" role="link" tabindex="0" aria-label="Open Lightbox" style="cursor:pointer;"><picture><img class="zpimage zpimage-style-none zpimage-space-none " src="/tech_2.png" size="custom" data-lightbox="true"/></picture></span></figure></div>
-</div></div><div data-element-id="elm_qUhd99MoOgvrjpEiijOtIA" data-element-type="column" class="zpelem-col zpcol-12 zpcol-md-8 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg "><style type="text/css"> [data-element-id="elm_qUhd99MoOgvrjpEiijOtIA"].zpelem-col{ margin-block-start:-2px; } </style><div data-element-id="elm_PsC0Vb5wnXyQ4JluuDYFKA" data-element-type="heading" class="zpelement zpelem-heading "><style></style><h2
- class="zpheading zpheading-style-none zpheading-align-left zpheading-align-mobile-left zpheading-align-tablet-left " data-editor="true"><div style="color:inherit;"><h3 style="font-size:24px;">Advanced Encryption</h3></div></h2></div>
-<div data-element-id="elm_4DveLsdYyRS6YQG9e6gDXQ" data-element-type="text" class="zpelement zpelem-text "><style></style><div class="zptext zptext-align-left zptext-align-mobile-left zptext-align-tablet-left " data-editor="true"><p><span style="color:inherit;">Protect your organization’s wireless data from eavesdropping and other forms of cyberattacks. WPA-Enterprise uses the Advanced Encryption Standard (AES) and Temporal Key Integrity Protocol (TKIP) to encrypt wireless data and protect it from unauthorized access.</span></p></div>
-</div><div data-element-id="elm_lM-11Dpn0f4Mouf2LZsS1w" data-element-type="button" class="zpelement zpelem-button "><style></style><div class="zpbutton-container zpbutton-align-left zpbutton-align-mobile-left zpbutton-align-tablet-left"><style type="text/css"></style><a class="zpbutton-wrapper zpbutton zpbutton-type-primary zpbutton-size-md zpbutton-style-none " href="https://help.ironwifi.com/portal"><span class="zpbutton-content">LEARN MORE</span></a></div>
-</div></div></div></div></div><div data-element-id="elm_YwrvrcqQNDpjVWaPkjcRRg" data-element-type="section" class="zpsection zpdefault-section zpdefault-section-bg "><style type="text/css"> [data-element-id="elm_YwrvrcqQNDpjVWaPkjcRRg"].zpsection{ padding-block-start:3px; padding-block-end:2px; } </style><div class="zpcontainer-fluid zpcontainer"><div data-element-id="elm_01nx9SeqgJQLiDyd2--EOA" data-element-type="row" class="zprow zprow-container zpalign-items-center zpjustify-content-flex-start " data-equal-column=""><style type="text/css"></style><div data-element-id="elm_0t-KR7KlUo3fCMBLF97nHg" data-element-type="column" class="zpelem-col zpcol-12 zpcol-md-6 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg "><style type="text/css"></style><div data-element-id="elm_g2iCuXdYr9CtD8iI0t3sSQ" data-element-type="heading" class="zpelement zpelem-heading "><style> [data-element-id="elm_g2iCuXdYr9CtD8iI0t3sSQ"].zpelem-heading { margin-block-start:-11px; } </style><h3
- class="zpheading zpheading-style-none zpheading-align-left zpheading-align-mobile-left zpheading-align-tablet-left " data-editor="true"><span style="color:inherit;"><span style="font-size:24px;">Secure Authentication</span></span></h3></div>
-<div data-element-id="elm_vpmoCexW334GuCP6N7Pl9w" data-element-type="text" class="zpelement zpelem-text "><style></style><div class="zptext zptext-align-left zptext-align-mobile-left zptext-align-tablet-left " data-editor="true"><div style="color:inherit;"><div style="color:inherit;"><p><span style="font-size:16px;">IronWiFi allows you to encrypt your data and protect it from unauthorized access with Advanced Encryption Standard (AES) and Temporal Key Integrity Protocol (TKIP). Users can also be authenticated easily with EAP (Extensible Authentication Protocol), which integrates seamlessly with a RADIUS server for centralized user authentication and management.</span></p><p><span style="font-size:16px;">Keep reading below for more information.</span></p></div></div></div>
-</div><div data-element-id="elm_0ALAnybIWGzw_glFCWYmxw" data-element-type="text" class="zpelement zpelem-text "><style></style><div class="zptext zptext-align-center zptext-align-mobile-center zptext-align-tablet-center " data-editor="true"><p style="text-align:left;"><br/></p></div>
-</div><div data-element-id="elm_qLyXPlOQiaVRCC5Ao41N0w" data-element-type="button" class="zpelement zpelem-button "><style></style><div class="zpbutton-container zpbutton-align-center zpbutton-align-mobile-center zpbutton-align-tablet-center"><style type="text/css"></style><a class="zpbutton-wrapper zpbutton zpbutton-type-primary zpbutton-size-md zpbutton-style-none " href="https://help.ironwifi.com/portal"><span class="zpbutton-content">LEARN MORE</span></a></div>
-</div></div><div data-element-id="elm_ThWr_kSH_J5XjMEEa5GdnA" data-element-type="column" class="zpelem-col zpcol-12 zpcol-md-6 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg "><style type="text/css"></style><div data-element-id="elm_WM_P9NSpfKOukqr9jyr8ow" data-element-type="image" class="zpelement zpelem-image "><style> @media (min-width: 992px) { [data-element-id="elm_WM_P9NSpfKOukqr9jyr8ow"] .zpimage-container figure img { width: 454.62px !important ; height: 400px !important ; } } </style><div data-caption-color="" data-size-tablet="" data-size-mobile="" data-align="center" data-tablet-image-separate="false" data-mobile-image-separate="false" class="zpimage-container zpimage-align-center zpimage-tablet-align-center zpimage-mobile-align-center zpimage-size-custom zpimage-tablet-fallback-fit zpimage-mobile-fallback-fit hb-lightbox " data-lightbox-options="
+                theme:dark" data-mobile-image-separate="false" data-size-mobile="" data-size-tablet="" data-tablet-image-separate="false">
+            <figure class="zpimage-data-ref" role="none">
+             <span aria-label="Open Lightbox" class="zpimage-anchor" role="link" style="cursor:pointer;" tabindex="0">
+              <picture>
+               <img alt="Technical diagram" class="zpimage zpimage-style-none zpimage-space-none" data-lightbox="true" size="custom" src="/tech_2.png"/>
+              </picture>
+             </span>
+            </figure>
+           </div>
+          </div>
+         </div>
+         <div class="zpelem-col zpcol-12 zpcol-md-8 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg" data-element-id="elm_qUhd99MoOgvrjpEiijOtIA" data-element-type="column">
+          <style type="text/css">
+           [data-element-id="elm_qUhd99MoOgvrjpEiijOtIA"].zpelem-col{ margin-block-start:-2px; }
+          </style>
+          <div class="zpelement zpelem-heading" data-element-id="elm_PsC0Vb5wnXyQ4JluuDYFKA" data-element-type="heading">
+           <style>
+           </style>
+           <h2 class="zpheading zpheading-style-none zpheading-align-left zpheading-align-mobile-left zpheading-align-tablet-left" data-editor="true">
+            <div style="color:inherit;">
+             <h3 style="font-size:24px;">
+              Advanced Encryption
+             </h3>
+            </div>
+           </h2>
+          </div>
+          <div class="zpelement zpelem-text" data-element-id="elm_4DveLsdYyRS6YQG9e6gDXQ" data-element-type="text">
+           <style>
+           </style>
+           <div class="zptext zptext-align-left zptext-align-mobile-left zptext-align-tablet-left" data-editor="true">
+            <p>
+             <span style="color:inherit;">
+              Protect your organization’s wireless data from eavesdropping and other forms of cyberattacks. WPA-Enterprise uses the Advanced Encryption Standard (AES) and Temporal Key Integrity Protocol (TKIP) to encrypt wireless data and protect it from unauthorized access.
+             </span>
+            </p>
+           </div>
+          </div>
+          <div class="zpelement zpelem-button" data-element-id="elm_lM-11Dpn0f4Mouf2LZsS1w" data-element-type="button">
+           <style>
+           </style>
+           <div class="zpbutton-container zpbutton-align-left zpbutton-align-mobile-left zpbutton-align-tablet-left">
+            <style type="text/css">
+            </style>
+            <a class="zpbutton-wrapper zpbutton zpbutton-type-primary zpbutton-size-md zpbutton-style-none" href="https://help.ironwifi.com/portal">
+             <span class="zpbutton-content">
+              LEARN MORE
+             </span>
+            </a>
+           </div>
+          </div>
+         </div>
+        </div>
+       </div>
+      </div>
+      <div class="zpsection zpdefault-section zpdefault-section-bg" data-element-id="elm_YwrvrcqQNDpjVWaPkjcRRg" data-element-type="section">
+       <style type="text/css">
+        [data-element-id="elm_YwrvrcqQNDpjVWaPkjcRRg"].zpsection{ padding-block-start:3px; padding-block-end:2px; }
+       </style>
+       <div class="zpcontainer-fluid zpcontainer">
+        <div class="zprow zprow-container zpalign-items-center zpjustify-content-flex-start" data-element-id="elm_01nx9SeqgJQLiDyd2--EOA" data-element-type="row" data-equal-column="">
+         <style type="text/css">
+         </style>
+         <div class="zpelem-col zpcol-12 zpcol-md-6 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg" data-element-id="elm_0t-KR7KlUo3fCMBLF97nHg" data-element-type="column">
+          <style type="text/css">
+          </style>
+          <div class="zpelement zpelem-heading" data-element-id="elm_g2iCuXdYr9CtD8iI0t3sSQ" data-element-type="heading">
+           <style>
+            [data-element-id="elm_g2iCuXdYr9CtD8iI0t3sSQ"].zpelem-heading { margin-block-start:-11px; }
+           </style>
+           <h3 class="zpheading zpheading-style-none zpheading-align-left zpheading-align-mobile-left zpheading-align-tablet-left" data-editor="true">
+            <span style="color:inherit;">
+             <span style="font-size:24px;">
+              Secure Authentication
+             </span>
+            </span>
+           </h3>
+          </div>
+          <div class="zpelement zpelem-text" data-element-id="elm_vpmoCexW334GuCP6N7Pl9w" data-element-type="text">
+           <style>
+           </style>
+           <div class="zptext zptext-align-left zptext-align-mobile-left zptext-align-tablet-left" data-editor="true">
+            <div style="color:inherit;">
+             <div style="color:inherit;">
+          </div>
+          <div class="zpelement zpelem-text" data-element-id="elm_0ALAnybIWGzw_glFCWYmxw" data-element-type="text">
+           <style>
+           </style>
+           <div class="zptext zptext-align-center zptext-align-mobile-center zptext-align-tablet-center" data-editor="true">
+            <p style="text-align:left;">
+             <br/>
+            </p>
+           </div>
+          </div>
+          <div class="zpelement zpelem-button" data-element-id="elm_qLyXPlOQiaVRCC5Ao41N0w" data-element-type="button">
+           <style>
+           </style>
+           <div class="zpbutton-container zpbutton-align-center zpbutton-align-mobile-center zpbutton-align-tablet-center">
+            <style type="text/css">
+            </style>
+            <a class="zpbutton-wrapper zpbutton zpbutton-type-primary zpbutton-size-md zpbutton-style-none" href="https://help.ironwifi.com/portal">
+             <span class="zpbutton-content">
+              LEARN MORE
+             </span>
+            </a>
+           </div>
+          </div>
+         </div>
+         <div class="zpelem-col zpcol-12 zpcol-md-6 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg" data-element-id="elm_ThWr_kSH_J5XjMEEa5GdnA" data-element-type="column">
+          <style type="text/css">
+          </style>
+          <div class="zpelement zpelem-image" data-element-id="elm_WM_P9NSpfKOukqr9jyr8ow" data-element-type="image">
+           <style>
+            @media (min-width: 992px) { [data-element-id="elm_WM_P9NSpfKOukqr9jyr8ow"] .zpimage-container figure img { width: 454.62px !important ; height: 400px !important ; } }
+           </style>
+           <div class="zpimage-container zpimage-align-center zpimage-tablet-align-center zpimage-mobile-align-center zpimage-size-custom zpimage-tablet-fallback-fit zpimage-mobile-fallback-fit hb-lightbox" data-align="center" data-caption-color="" data-lightbox-options="
                 type:fullscreen,
-                theme:dark"><figure role="none" class="zpimage-data-ref"><span class="zpimage-anchor" role="link" tabindex="0" aria-label="Open Lightbox" style="cursor:pointer;"><picture><img class="zpimage zpimage-style-none zpimage-space-none " src="/wap_5.png" size="custom" data-lightbox="true"/></picture></span></figure></div>
-</div></div></div></div></div><div data-element-id="elm_ZThQDvZ7nSESq3daXai8zw" data-element-type="section" class="zpsection zpdefault-section zpdefault-section-bg "><style type="text/css"> [data-element-id="elm_ZThQDvZ7nSESq3daXai8zw"].zpsection{ border-radius:1px; padding-block-start:27px; } </style><div class="zpcontainer-fluid zpcontainer"><div data-element-id="elm_0GHp50q9nT9GXQHYDZkqPw" data-element-type="row" class="zprow zprow-container zpalign-items-flex-start zpjustify-content-flex-start zpdefault-section zpdefault-section-bg " data-equal-column="false"><style type="text/css"> [data-element-id="elm_0GHp50q9nT9GXQHYDZkqPw"].zprow{ border-radius:1px; } </style><div data-element-id="elm_4C0VgwZGlSY8iTlpA55plg" data-element-type="column" class="zpelem-col zpcol-12 zpcol-md-3 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg "><style type="text/css"></style><div data-element-id="elm_8xlDNNg06ZOxOAXO-b0gxA" data-element-type="image" class="zpelement zpelem-image "><style> @media (min-width: 992px) { [data-element-id="elm_8xlDNNg06ZOxOAXO-b0gxA"] .zpimage-container figure img { width: 295px !important ; height: 213px !important ; } } [data-element-id="elm_8xlDNNg06ZOxOAXO-b0gxA"].zpelem-image { margin-block-start:-21px; } </style><div data-caption-color="" data-size-tablet="" data-size-mobile="" data-align="center" data-tablet-image-separate="false" data-mobile-image-separate="false" class="zpimage-container zpimage-align-center zpimage-tablet-align-center zpimage-mobile-align-center zpimage-size-custom zpimage-tablet-fallback-fit zpimage-mobile-fallback-fit hb-lightbox " data-lightbox-options="
+                theme:dark" data-mobile-image-separate="false" data-size-mobile="" data-size-tablet="" data-tablet-image-separate="false">
+            <figure class="zpimage-data-ref" role="none">
+             <span aria-label="Open Lightbox" class="zpimage-anchor" role="link" style="cursor:pointer;" tabindex="0">
+              <picture>
+               <img alt="Wireless access point" class="zpimage zpimage-style-none zpimage-space-none" data-lightbox="true" size="custom" src="/wap_5.png"/>
+              </picture>
+             </span>
+            </figure>
+           </div>
+          </div>
+         </div>
+        </div>
+       </div>
+      </div>
+      <div class="zpsection zpdefault-section zpdefault-section-bg" data-element-id="elm_ZThQDvZ7nSESq3daXai8zw" data-element-type="section">
+       <style type="text/css">
+        [data-element-id="elm_ZThQDvZ7nSESq3daXai8zw"].zpsection{ border-radius:1px; padding-block-start:27px; }
+       </style>
+       <div class="zpcontainer-fluid zpcontainer">
+        <div class="zprow zprow-container zpalign-items-flex-start zpjustify-content-flex-start zpdefault-section zpdefault-section-bg" data-element-id="elm_0GHp50q9nT9GXQHYDZkqPw" data-element-type="row" data-equal-column="false">
+         <style type="text/css">
+          [data-element-id="elm_0GHp50q9nT9GXQHYDZkqPw"].zprow{ border-radius:1px; }
+         </style>
+         <div class="zpelem-col zpcol-12 zpcol-md-3 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg" data-element-id="elm_4C0VgwZGlSY8iTlpA55plg" data-element-type="column">
+          <style type="text/css">
+          </style>
+          <div class="zpelement zpelem-image" data-element-id="elm_8xlDNNg06ZOxOAXO-b0gxA" data-element-type="image">
+           <style>
+            @media (min-width: 992px) { [data-element-id="elm_8xlDNNg06ZOxOAXO-b0gxA"] .zpimage-container figure img { width: 295px !important ; height: 213px !important ; } } [data-element-id="elm_8xlDNNg06ZOxOAXO-b0gxA"].zpelem-image { margin-block-start:-21px; }
+           </style>
+           <div class="zpimage-container zpimage-align-center zpimage-tablet-align-center zpimage-mobile-align-center zpimage-size-custom zpimage-tablet-fallback-fit zpimage-mobile-fallback-fit hb-lightbox" data-align="center" data-caption-color="" data-lightbox-options="
                 type:fullscreen,
-                theme:dark"><figure role="none" class="zpimage-data-ref"><span class="zpimage-anchor" role="link" tabindex="0" aria-label="Open Lightbox" style="cursor:pointer;"><picture><img class="zpimage zpimage-style-none zpimage-space-none " src="/wap_2.png" size="custom" data-lightbox="true"/></picture></span></figure></div>
-</div></div><div data-element-id="elm_FJfy2c-WpBJJhRW4cejGWw" data-element-type="column" class="zpelem-col zpcol-12 zpcol-md-9 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg "><style type="text/css"></style><div data-element-id="elm_BSx_IO8u4qAUW3_hqf054Q" data-element-type="heading" class="zpelement zpelem-heading "><style></style><h2
- class="zpheading zpheading-style-none zpheading-align-left zpheading-align-mobile-left zpheading-align-tablet-left " data-editor="true"><span style="color:inherit;"><span style="font-size:24px;">High Flexibility</span></span></h2></div>
-<div data-element-id="elm_P69f3lyWpZHdSrTHOddAOQ" data-element-type="text" class="zpelement zpelem-text "><style></style><div class="zptext zptext-align-left zptext-align-mobile-left zptext-align-tablet-left " data-editor="true"><p><span style="color:inherit;">WPA-Enterprise supports a wide range of authentication methods, including EAP-TLS, EAP-TTLS, and PEAP, which allows it to work with a variety of existing user databases and authentication servers. This makes it a suitable choice for large businesses and organizations that need to authenticate a large number of users.&nbsp;</span></p></div>
-</div></div></div></div></div><div data-element-id="elm_s5WTEot65-tm-MhKdFtoaw" data-element-type="section" class="zpsection zpdefault-section zpdefault-section-bg "><style type="text/css"></style><div class="zpcontainer-fluid zpcontainer"><div data-element-id="elm_vnD6JQPzGdXj9xFWNfcTUg" data-element-type="row" class="zprow zprow-container zpalign-items-center zpjustify-content-flex-start " data-equal-column="false"><style type="text/css"> [data-element-id="elm_vnD6JQPzGdXj9xFWNfcTUg"].zprow{ margin-block-start:-40px; } </style><div data-element-id="elm_tBKGzoXwgURKmWCXrnFMmQ" data-element-type="column" class="zpelem-col zpcol-12 zpcol-md-6 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg "><style type="text/css"></style><div data-element-id="elm_UxVl3IfrpjktI2s95m4gLw" data-element-type="heading" class="zpelement zpelem-heading "><style></style><h3
- class="zpheading zpheading-style-none zpheading-align-left zpheading-align-mobile-left zpheading-align-tablet-left " data-editor="true"><span style="color:inherit;"><span style="font-size:24px;">Network Segmentation</span></span></h3></div>
-<div data-element-id="elm_sRzH7w8HzRXIwqrVZwXl5A" data-element-type="text" class="zpelement zpelem-text "><style></style><div class="zptext zptext-align-center zptext-align-mobile-center zptext-align-tablet-center " data-editor="true"><p style="text-align:left;"><span style="color:inherit;">Segment your network to better protect sensitive data and resources. WPA-Enterprise supports multiple SSIDs and VLANs, which allows for the creation of multiple wireless networks with different security levels.&nbsp;</span></p></div>
-</div><div data-element-id="elm_n9mL4AXDMqqoAtyB_oDJNg" data-element-type="button" class="zpelement zpelem-button "><style></style><div class="zpbutton-container zpbutton-align-center zpbutton-align-mobile-center zpbutton-align-tablet-center"><style type="text/css"></style><a class="zpbutton-wrapper zpbutton zpbutton-type-primary zpbutton-size-md zpbutton-style-none " href="https://help.ironwifi.com/portal"><span class="zpbutton-content">View More</span></a></div>
-</div></div><div data-element-id="elm_209VMukRJMyLPIQoXFMZdw" data-element-type="column" class="zpelem-col zpcol-12 zpcol-md-6 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg "><style type="text/css"></style><div data-element-id="elm_BI4w8zWYzliHH3mvOCTRSw" data-element-type="image" class="zpelement zpelem-image "><style> @media (min-width: 992px) { [data-element-id="elm_BI4w8zWYzliHH3mvOCTRSw"] .zpimage-container figure img { width: 463px !important ; height: 309px !important ; } } </style><div data-caption-color="" data-size-tablet="" data-size-mobile="" data-align="center" data-tablet-image-separate="false" data-mobile-image-separate="false" class="zpimage-container zpimage-align-center zpimage-tablet-align-center zpimage-mobile-align-center zpimage-size-custom zpimage-tablet-fallback-fit zpimage-mobile-fallback-fit hb-lightbox " data-lightbox-options="
+                theme:dark" data-mobile-image-separate="false" data-size-mobile="" data-size-tablet="" data-tablet-image-separate="false">
+            <figure class="zpimage-data-ref" role="none">
+             <span aria-label="Open Lightbox" class="zpimage-anchor" role="link" style="cursor:pointer;" tabindex="0">
+              <picture>
+               <img alt="Wireless access point" class="zpimage zpimage-style-none zpimage-space-none" data-lightbox="true" size="custom" src="/wap_2.png"/>
+              </picture>
+             </span>
+            </figure>
+           </div>
+          </div>
+         </div>
+         <div class="zpelem-col zpcol-12 zpcol-md-9 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg" data-element-id="elm_FJfy2c-WpBJJhRW4cejGWw" data-element-type="column">
+          <style type="text/css">
+          </style>
+          <div class="zpelement zpelem-heading" data-element-id="elm_BSx_IO8u4qAUW3_hqf054Q" data-element-type="heading">
+           <style>
+           </style>
+           <h2 class="zpheading zpheading-style-none zpheading-align-left zpheading-align-mobile-left zpheading-align-tablet-left" data-editor="true">
+            <span style="color:inherit;">
+             <span style="font-size:24px;">
+              High Flexibility
+             </span>
+            </span>
+           </h2>
+          </div>
+          <div class="zpelement zpelem-text" data-element-id="elm_P69f3lyWpZHdSrTHOddAOQ" data-element-type="text">
+           <style>
+           </style>
+           <div class="zptext zptext-align-left zptext-align-mobile-left zptext-align-tablet-left" data-editor="true">
+            <p>
+             <span style="color:inherit;">
+              WPA-Enterprise supports a wide range of authentication methods, including EAP-TLS, EAP-TTLS, and PEAP, which allows it to work with a variety of existing user databases and authentication servers. This makes it a suitable choice for large businesses and organizations that need to authenticate a large number of users.
+             </span>
+            </p>
+           </div>
+          </div>
+         </div>
+        </div>
+       </div>
+      </div>
+      <div class="zpsection zpdefault-section zpdefault-section-bg" data-element-id="elm_s5WTEot65-tm-MhKdFtoaw" data-element-type="section">
+       <style type="text/css">
+       </style>
+       <div class="zpcontainer-fluid zpcontainer">
+        <div class="zprow zprow-container zpalign-items-center zpjustify-content-flex-start" data-element-id="elm_vnD6JQPzGdXj9xFWNfcTUg" data-element-type="row" data-equal-column="false">
+         <style type="text/css">
+          [data-element-id="elm_vnD6JQPzGdXj9xFWNfcTUg"].zprow{ margin-block-start:-40px; }
+         </style>
+         <div class="zpelem-col zpcol-12 zpcol-md-6 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg" data-element-id="elm_tBKGzoXwgURKmWCXrnFMmQ" data-element-type="column">
+          <style type="text/css">
+          </style>
+          <div class="zpelement zpelem-heading" data-element-id="elm_UxVl3IfrpjktI2s95m4gLw" data-element-type="heading">
+           <style>
+           </style>
+           <h3 class="zpheading zpheading-style-none zpheading-align-left zpheading-align-mobile-left zpheading-align-tablet-left" data-editor="true">
+            <span style="color:inherit;">
+             <span style="font-size:24px;">
+              Network Segmentation
+             </span>
+            </span>
+           </h3>
+          </div>
+          <div class="zpelement zpelem-text" data-element-id="elm_sRzH7w8HzRXIwqrVZwXl5A" data-element-type="text">
+           <style>
+           </style>
+           <div class="zptext zptext-align-center zptext-align-mobile-center zptext-align-tablet-center" data-editor="true">
+            <p style="text-align:left;">
+             <span style="color:inherit;">
+              Segment your network to better protect sensitive data and resources. WPA-Enterprise supports multiple SSIDs and VLANs, which allows for the creation of multiple wireless networks with different security levels.
+             </span>
+            </p>
+           </div>
+          </div>
+          <div class="zpelement zpelem-button" data-element-id="elm_n9mL4AXDMqqoAtyB_oDJNg" data-element-type="button">
+           <style>
+           </style>
+           <div class="zpbutton-container zpbutton-align-center zpbutton-align-mobile-center zpbutton-align-tablet-center">
+            <style type="text/css">
+            </style>
+            <a class="zpbutton-wrapper zpbutton zpbutton-type-primary zpbutton-size-md zpbutton-style-none" href="https://help.ironwifi.com/portal">
+             <span class="zpbutton-content">
+              View More
+             </span>
+            </a>
+           </div>
+          </div>
+         </div>
+         <div class="zpelem-col zpcol-12 zpcol-md-6 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg" data-element-id="elm_209VMukRJMyLPIQoXFMZdw" data-element-type="column">
+          <style type="text/css">
+          </style>
+          <div class="zpelement zpelem-image" data-element-id="elm_BI4w8zWYzliHH3mvOCTRSw" data-element-type="image">
+           <style>
+            @media (min-width: 992px) { [data-element-id="elm_BI4w8zWYzliHH3mvOCTRSw"] .zpimage-container figure img { width: 463px !important ; height: 309px !important ; } }
+           </style>
+           <div class="zpimage-container zpimage-align-center zpimage-tablet-align-center zpimage-mobile-align-center zpimage-size-custom zpimage-tablet-fallback-fit zpimage-mobile-fallback-fit hb-lightbox" data-align="center" data-caption-color="" data-lightbox-options="
                 type:fullscreen,
-                theme:dark"><figure role="none" class="zpimage-data-ref"><span class="zpimage-anchor" role="link" tabindex="0" aria-label="Open Lightbox" style="cursor:pointer;"><picture><img class="zpimage zpimage-style-none zpimage-space-none " src="/wap_3.png" size="custom" data-lightbox="true"/></picture></span></figure></div>
-</div></div></div></div></div><div data-element-id="elm_Za2qXm8kci2TBdHXifcjGw" data-element-type="section" class="zpsection zpdefault-section zpdefault-section-bg "><style type="text/css"> [data-element-id="elm_Za2qXm8kci2TBdHXifcjGw"].zpsection{ padding-block-end:2px; } </style><div class="zpcontainer-fluid zpcontainer"><div data-element-id="elm_UwiuhIpUEszshCRXyr6MkQ" data-element-type="row" class="zprow zprow-container zpalign-items-flex-start zpjustify-content-flex-start zpdefault-section zpdefault-section-bg " data-equal-column="false"><style type="text/css"></style><div data-element-id="elm_bBZpR4SQEEx-K6rCselwtQ" data-element-type="column" class="zpelem-col zpcol-12 zpcol-md-12 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg "><style type="text/css"></style><div data-element-id="elm_lHLak7DwPxKNcvjx3XUOWA" data-element-type="heading" class="zpelement zpelem-heading "><style> [data-element-id="elm_lHLak7DwPxKNcvjx3XUOWA"].zpelem-heading { margin-block-start:-79px; } </style><h2
- class="zpheading zpheading-style-none zpheading-align-left zpheading-align-mobile-left zpheading-align-tablet-left " data-editor="true"><div style="color:inherit;"><h2><span style="font-size:14px;">TESTIMONIALS</span></h2></div></h2></div>
-<div data-element-id="elm_455Ga_GbTzYXWgpe22vwfg" data-element-type="heading" class="zpelement zpelem-heading "><style></style><h2
- class="zpheading zpheading-style-none zpheading-align-left zpheading-align-mobile-left zpheading-align-tablet-left " data-editor="true"><div style="color:inherit;"><h2 style="font-size:32px;">What our customers say</h2></div></h2></div>
-</div></div></div></div><div data-element-id="elm_SxrXAPJN3qQYFLrWgKXFFw" data-element-type="section" class="zpsection zpdefault-section zpdefault-section-bg zscustom-section-29 "><style type="text/css"> [data-element-id="elm_SxrXAPJN3qQYFLrWgKXFFw"].zpsection{ padding-block-start:9px; } </style><div class="zpcontainer-fluid zpcontainer"><div data-element-id="elm_EV4WT7UoxRptvDDwYNOVtA" data-element-type="row" class="zprow zprow-container zpalign-items-flex-start zpjustify-content-flex-start " data-equal-column="false"><style type="text/css"></style><div data-element-id="elm_hOu-4P6EjQjykLhxEsYz2Q" data-element-type="column" class="zpelem-col zpcol-12 zpcol-md-4 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg "><style type="text/css"> [data-element-id="elm_hOu-4P6EjQjykLhxEsYz2Q"].zpelem-col{ margin-block-start:-24px; } </style><div data-element-id="elm_eDa7n-yHNE9xDnaeMUjMTQ" data-element-type="box" class="zpelem-box zpelement zpbox-container zsbox-container-style-02 zpdefault-section zpdefault-section-bg "><style type="text/css"></style><div data-element-id="elm_J4bGX_vPMAtfAsQd1mQJeA" data-element-type="icon" class="zpelement zpelem-icon "><style type="text/css"></style><div class="zpicon-container zpicon-align-left zpicon-align-mobile-left zpicon-align-tablet-left"><style></style><span class="zpicon zpicon-common zpicon-anchor zpicon-size-md zpicon-style-none "><svg viewBox="0 0 512 512" height="512" width="512" aria-label="hidden" xmlns="http://www.w3.org/2000/svg"><path d="M464 256h-80v-64c0-35.3 28.7-64 64-64h8c13.3 0 24-10.7 24-24V56c0-13.3-10.7-24-24-24h-8c-88.4 0-160 71.6-160 160v240c0 26.5 21.5 48 48 48h128c26.5 0 48-21.5 48-48V304c0-26.5-21.5-48-48-48zm-288 0H96v-64c0-35.3 28.7-64 64-64h8c13.3 0 24-10.7 24-24V56c0-13.3-10.7-24-24-24h-8C71.6 32 0 103.6 0 192v240c0 26.5 21.5 48 48 48h128c26.5 0 48-21.5 48-48V304c0-26.5-21.5-48-48-48z"></path></svg></span></div>
-</div><div data-element-id="elm_gxTdFdGSmz2ZInojx8F3sg" data-element-type="text" class="zpelement zpelem-text "><style></style><div class="zptext zptext-align-left zptext-align-mobile-left zptext-align-tablet-left " data-editor="true"><p><span style="color:inherit;">&quot;Needless to say we are extremely satisfied with the results. Thanks guys, keep up the good work! Your Captive Portal is great. Your solution has really helped our business.&quot;</span></p><p><br/></p><p><span style="color:inherit;font-size:12px;"><span style="font-weight:700;margin-bottom:8px;">MARKETING MANAGER</span></span></p><p><span style="color:inherit;"><span style="font-weight:700;">Nady Cane</span></span><span style="color:inherit;"></span></p></div>
-</div></div></div><div data-element-id="elm_9GUrX0lDissaVzM-iSARsw" data-element-type="column" class="zpelem-col zpcol-12 zpcol-md-4 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg "><style type="text/css"></style><div data-element-id="elm_DOfhOBihMeoX-fcnXRLSpQ" data-element-type="box" class="zpelem-box zpelement zpbox-container zsbox-container-style-02 zpdefault-section zpdefault-section-bg "><style type="text/css"> [data-element-id="elm_DOfhOBihMeoX-fcnXRLSpQ"].zpelem-box{ margin-block-start:-6px; } </style><div data-element-id="elm_x8zd5_v1HzawBVq6Nn6dSQ" data-element-type="icon" class="zpelement zpelem-icon "><style type="text/css"></style><div class="zpicon-container zpicon-align-left zpicon-align-mobile-left zpicon-align-tablet-left"><style></style><span class="zpicon zpicon-common zpicon-anchor zpicon-size-md zpicon-style-none "><svg viewBox="0 0 512 512" height="512" width="512" aria-label="hidden" xmlns="http://www.w3.org/2000/svg"><path d="M464 256h-80v-64c0-35.3 28.7-64 64-64h8c13.3 0 24-10.7 24-24V56c0-13.3-10.7-24-24-24h-8c-88.4 0-160 71.6-160 160v240c0 26.5 21.5 48 48 48h128c26.5 0 48-21.5 48-48V304c0-26.5-21.5-48-48-48zm-288 0H96v-64c0-35.3 28.7-64 64-64h8c13.3 0 24-10.7 24-24V56c0-13.3-10.7-24-24-24h-8C71.6 32 0 103.6 0 192v240c0 26.5 21.5 48 48 48h128c26.5 0 48-21.5 48-48V304c0-26.5-21.5-48-48-48z"></path></svg></span></div>
-</div><div data-element-id="elm_6MvkF6O7uQAh1l9kYFrsjg" data-element-type="text" class="zpelement zpelem-text "><style></style><div class="zptext zptext-align-left zptext-align-mobile-left zptext-align-tablet-left " data-editor="true"><div style="color:inherit;"><p>&quot;I would also like to say thank you to all your staff. I love IronWiFi. Your platform was worth a fortune to my company.&quot;</p><p><br/></p><p><br/></p><p><span style="font-size:12px;"><span style="margin-bottom:8px;font-weight:700;">MARKETING SPECIALIST</span></span></p><p><span style="font-weight:700;">Joe Kaiser</span></p></div></div>
-</div></div></div><div data-element-id="elm_jq5POv4c-c1SvgtcvfU0HQ" data-element-type="column" class="zpelem-col zpcol-12 zpcol-md-4 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg "><style type="text/css"></style><div data-element-id="elm_thAEYrphfeg_PH9teCpkPw" data-element-type="box" class="zpelem-box zpelement zpbox-container zsbox-container-style-02 zpdefault-section zpdefault-section-bg "><style type="text/css"> [data-element-id="elm_thAEYrphfeg_PH9teCpkPw"].zpelem-box{ margin-block-start:-5px; } </style><div data-element-id="elm_U2Yp_ENPhHcV-XHKk2WLEw" data-element-type="icon" class="zpelement zpelem-icon "><style type="text/css"></style><div class="zpicon-container zpicon-align-left zpicon-align-mobile-left zpicon-align-tablet-left"><style></style><span class="zpicon zpicon-common zpicon-anchor zpicon-size-md zpicon-style-none "><svg viewBox="0 0 512 512" height="512" width="512" aria-label="hidden" xmlns="http://www.w3.org/2000/svg"><path d="M464 256h-80v-64c0-35.3 28.7-64 64-64h8c13.3 0 24-10.7 24-24V56c0-13.3-10.7-24-24-24h-8c-88.4 0-160 71.6-160 160v240c0 26.5 21.5 48 48 48h128c26.5 0 48-21.5 48-48V304c0-26.5-21.5-48-48-48zm-288 0H96v-64c0-35.3 28.7-64 64-64h8c13.3 0 24-10.7 24-24V56c0-13.3-10.7-24-24-24h-8C71.6 32 0 103.6 0 192v240c0 26.5 21.5 48 48 48h128c26.5 0 48-21.5 48-48V304c0-26.5-21.5-48-48-48z"></path></svg></span></div>
-</div><div data-element-id="elm_331WRuA7n_u0PXEVfzYZ8A" data-element-type="text" class="zpelement zpelem-text "><style></style><div class="zptext zptext-align-left zptext-align-mobile-left zptext-align-tablet-left " data-editor="true"><p><span style="color:inherit;">&quot;We are always looking for ways to improve our customers' experiences, and this new service will help us achieve that goal.&quot;</span></p><p><span style="color:inherit;"><br/></span></p><p><span style="color:inherit;"><br/></span></p><p><span style="color:inherit;font-size:12px;"><span style="font-weight:700;margin-bottom:8px;">HOTEL MANAGER</span></span></p><p><span style="color:inherit;"><span style="font-weight:700;">Anna Brown</span></span></p></div>
-</div></div></div></div></div></div><div data-element-id="elm_vdftGwRissyZ7wlf5e-6mQ" data-element-type="section" class="zpsection zplight-section zplight-section-bg zscustom-section-178 " style="background-color:rgba(161, 196, 232, 0.26);background-image:unset;"><style type="text/css"> [data-element-id="elm_vdftGwRissyZ7wlf5e-6mQ"].zpsection{ padding-block-start:1px; padding-block-end:1px; } </style><div class="zpcontainer-fluid zpcontainer"><div data-element-id="elm_KENNAwQAmolYSSqUbnFikQ" data-element-type="row" class="zprow zprow-container zpalign-items-flex-start zpjustify-content-center " data-equal-column=""><style type="text/css"></style><div data-element-id="elm_Fk4szMCkeIgnGUjGo_kXAw" data-element-type="column" class="zpelem-col zpcol-12 zpcol-md-12 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg "><style type="text/css"></style><div data-element-id="elm_2TQa7AqYsB_9XeUNQMkFng" data-element-type="heading" class="zpelement zpelem-heading "><style></style><h2
- class="zpheading zpheading-style-none zpheading-align-left zpheading-align-mobile-left zpheading-align-tablet-left " data-editor="true"><div style="color:inherit;"><h2 style="font-size:30px;">3 Steps to Starting IronWiFi</h2></div></h2></div>
-</div><div data-element-id="elm_Ni9_1sDZkSGFrFGggjKlGw" data-element-type="column" class="zpelem-col zpcol-12 zpcol-md-12 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg "><style type="text/css"></style><div data-element-id="elm_WWz2X_xMOkfHaFqkw0ZjOw" data-element-type="text" class="zpelement zpelem-text zsmobile-align-center "><style></style><div class="zptext zptext-align-left zptext-align-mobile-left zptext-align-tablet-left " data-editor="true"><div style="color:inherit;"><div><h4 style="font-size:18px;"><span style="font-weight:700;">01&nbsp; Set up an IronWiFi account</span></h4></div><p>&nbsp; &nbsp; &nbsp; &nbsp;Simply provide a few basic details: name, email, phone, and password.</p><p><br/></p><div><h4 style="font-size:18px;"><span style="font-weight:700;">02&nbsp; Configure your Wireless Access Points</span></h4></div><p>&nbsp; &nbsp; &nbsp; &nbsp;Configure IronWiFi's authentication service.</p><p><br/></p><div><h4 style="font-size:18px;"><span style="font-weight:700;">03&nbsp; Set up monitoring and reporting</span></h4></div><p>&nbsp; &nbsp; &nbsp; &nbsp;IronWiFi will start processing your requests while you explore the app’s features.</p></div></div>
-</div></div><div data-element-id="elm_4cEsbnuo8X9RI85vLYew0A" data-element-type="column" class="zpelem-col zpcol-12 zpcol-md-8 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg "><style type="text/css"></style><div data-element-id="elm_NmG_ElNMSwIRcPCrUEdGtA" data-element-type="row" class="zprow zprow-container zpalign-items-flex-start zpjustify-content-flex-start " data-equal-column=""><style type="text/css"></style><div data-element-id="elm_sBHMldZWh1uvoFs7sMcwVw" data-element-type="column" class="zpelem-col zpcol-12 zpcol-md-12 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg "><style type="text/css"></style><div data-element-id="elm_LsDXf0vz2McbjcH3-J32kw" data-element-type="spacer" class="zpelement zpelem-spacer "><style> div[data-element-id="elm_LsDXf0vz2McbjcH3-J32kw"] div.zpspacer { height:0px; } @media (max-width: 768px) { div[data-element-id="elm_LsDXf0vz2McbjcH3-J32kw"] div.zpspacer { height:calc(0px / 3); } } </style><div class="zpspacer " data-height="0"></div>
-</div></div></div><div data-element-id="elm_HMur-kFjkFTJvxt_oI0qHg" data-element-type="row" class="zprow zprow-container zpalign-items-flex-start zpjustify-content-flex-start " data-equal-column=""><style type="text/css"></style><div data-element-id="elm_nyLJMjLIrOO2nCAkAdbOEA" data-element-type="column" class="zpelem-col zpcol-12 zpcol-md-12 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg "><style type="text/css"></style><div data-element-id="elm_FunE6D_MB4tz2nP2sGfFDg" data-element-type="spacer" class="zpelement zpelem-spacer "><style> div[data-element-id="elm_FunE6D_MB4tz2nP2sGfFDg"] div.zpspacer { height:30px; } @media (max-width: 768px) { div[data-element-id="elm_FunE6D_MB4tz2nP2sGfFDg"] div.zpspacer { height:calc(30px / 3); } } </style><div class="zpspacer " data-height="30"></div>
-</div></div></div></div></div></div></div></div></div></div></div><div style="clear:both;"></div>
-<div role="contentinfo" class="theme-footer-area zpdark-section zpdark-section-bg theme-pages-full-stretch "><div data-footer-type='site_footer'><div class="zpcontent-container footer-container "><div data-element-id="elm_YeB85FftQm6R6T-8K8a8Aw" data-element-type="section" class="zpsection zpdefault-section zpdefault-section-bg "><style type="text/css"> [data-element-id="elm_YeB85FftQm6R6T-8K8a8Aw"].zpsection{ border-radius:1px; } </style><div class="zpcontainer-fluid zpcontainer"><div data-element-id="elm_FAKGXANeRKSRfWxlZ72THA" data-element-type="row" class="zprow zprow-container zpalign-items-center zpjustify-content-flex-start zpdefault-section zpdefault-section-bg " data-equal-column="false"><style type="text/css"> [data-element-id="elm_FAKGXANeRKSRfWxlZ72THA"].zprow{ border-radius:1px; } </style><div data-element-id="elm_KVIG1N7BQmaQddL86ydqNA" data-element-type="column" class="zpelem-col zpcol-12 zpcol-md-4 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg "><style type="text/css"> [data-element-id="elm_KVIG1N7BQmaQddL86ydqNA"].zpelem-col{ border-radius:1px; } </style><div data-element-id="elm_x8KYFBT3gnxVOdMAbxQ-lw" data-element-type="text" class="zpelement zpelem-text "><style></style><div class="zptext zptext-align-left zptext-align-mobile-left zptext-align-tablet-left " data-editor="true"><p><span style="font-size:13px;">Sales: &nbsp;<a href="mailto:sales@ironwifi.com">sales@ironwifi.com</a></span></p><div><p><span style="font-size:13px;">Technical: &nbsp;<a href="mailto:support@ironwifi.com">support@ironwifi.com</a></span></p><p style="line-height:2;"><span style="font-size:13px;">Emergency phone number:&nbsp;</span><span style="font-size:13px;">+1 (800) 963-6221</span></p></div></div>
-</div></div><div data-element-id="elm_mBQBQqgDThmZCL6i-VjeCA" data-element-type="column" class="zpelem-col zpcol-12 zpcol-md-4 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg "><style type="text/css"> [data-element-id="elm_mBQBQqgDThmZCL6i-VjeCA"].zpelem-col{ border-radius:1px; } </style><div class="zpapp " data-element-id="elm_ZQjLQ8RQyVxH8rVt1EssmA" data-element-type="app" data-zs-app="menu_app" data-app-type="menu_app" data-vertical_style="none" data-horizontal_style="none" data-tag="h4" data-align="left" data-type="horizontal" data-heading_toggle="false" data-hide_submenu_toggle="true" data-menu_label="Quick Links"><div class="app-container"></div>
-</div></div><div data-element-id="elm_9GY_56c9S_u8sCsLgzgOjg" data-element-type="column" class="zpelem-col zpcol-12 zpcol-md-4 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg "><style type="text/css"> [data-element-id="elm_9GY_56c9S_u8sCsLgzgOjg"].zpelem-col{ border-radius:1px; } </style><div data-element-id="elm_ObM-ur4_T3qedOgP1qYOJw" itemscope="" data-element-type="socialprofile" class="zpelement zpelem-socialprofile" data-element-id="elm_ObM-ur4_T3qedOgP1qYOJw" data-animation-name="fadeInUp"><style type="text/css"> [data-element-id="elm_ObM-ur4_T3qedOgP1qYOJw"].zpelem-socialprofile{ border-radius:1px; } </style><div data-socialprofile_container class="zpsocialprofile-container zpsocialprofile-size-md zpsocialprofile-halign-center zpsocialprofile-align-mobile-center zpsocialprofile-align-tablet-center zpsocialprofile-style-none zpsocialprofile-type-white "><a href="https://www.linkedin.com/company/ironwifi/" class="zpsocialprofile-wrapper zpsocialprofile-linkedin" target="_blank" aria-label="LinkedIn"><svg aria-hidden="true" class="zpsocialprofile" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg"><path d="M64 4.706v54.588A4.706 4.706 0 0 1 59.294 64H4.706A4.706 4.706 0 0 1 0 59.294V4.706A4.706 4.706 0 0 1 4.706 0h54.588A4.706 4.706 0 0 1 64 4.706zM18.824 24.47H9.412v30.117h9.412V24.471zm.847-10.353a5.421 5.421 0 0 0-5.384-5.46h-.17a5.459 5.459 0 0 0 0 10.918 5.421 5.421 0 0 0 5.554-5.289v-.17zm34.917 22.174c0-9.054-5.76-12.574-11.482-12.574a10.73 10.73 0 0 0-9.525 4.856h-.263v-4.103H24.47v30.117h9.411V38.57a6.25 6.25 0 0 1 5.647-6.738h.358c2.993 0 5.214 1.882 5.214 6.625v16.132h9.412l.075-18.296z"/></svg></a></div>
-</div></div></div><div data-element-id="elm_z43UtPRvTaOaG58G1bpkgA" data-element-type="row" class="zprow zprow-container zpalign-items-flex-start zpjustify-content-flex-start zpdefault-section zpdefault-section-bg " data-equal-column=""><style type="text/css"> [data-element-id="elm_z43UtPRvTaOaG58G1bpkgA"].zprow{ border-radius:1px; } </style><div data-element-id="elm_QETQbjDLTbu2SwOzEQTaOQ" data-element-type="column" class="zpelem-col zpcol-12 zpcol-md-12 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg "><style type="text/css"> [data-element-id="elm_QETQbjDLTbu2SwOzEQTaOQ"].zpelem-col{ border-radius:1px; } </style><div data-element-id="elm_m4BUuVRFSRWVgmJ2JaxfIA" data-element-type="spacer" class="zpelement zpelem-spacer "><style> div[data-element-id="elm_m4BUuVRFSRWVgmJ2JaxfIA"] div.zpspacer { height:1px; } @media (max-width: 768px) { div[data-element-id="elm_m4BUuVRFSRWVgmJ2JaxfIA"] div.zpspacer { height:calc(1px / 3); } } </style><div class="zpspacer " data-height="1"></div>
-</div></div></div></div></div></div></div></div><div class="zpmm-backdrop zpmm-backdrop-enabled"></div>
-</body></html>
+                theme:dark" data-mobile-image-separate="false" data-size-mobile="" data-size-tablet="" data-tablet-image-separate="false">
+            <figure class="zpimage-data-ref" role="none">
+             <span aria-label="Open Lightbox" class="zpimage-anchor" role="link" style="cursor:pointer;" tabindex="0">
+              <picture>
+               <img alt="Wireless access point" class="zpimage zpimage-style-none zpimage-space-none" data-lightbox="true" size="custom" src="/wap_3.png"/>
+              </picture>
+             </span>
+            </figure>
+           </div>
+          </div>
+         </div>
+        </div>
+       </div>
+      </div>
+      <div class="zpsection zpdefault-section zpdefault-section-bg" data-element-id="elm_Za2qXm8kci2TBdHXifcjGw" data-element-type="section">
+       <style type="text/css">
+        [data-element-id="elm_Za2qXm8kci2TBdHXifcjGw"].zpsection{ padding-block-end:2px; }
+       </style>
+       <div class="zpcontainer-fluid zpcontainer">
+        <div class="zprow zprow-container zpalign-items-flex-start zpjustify-content-flex-start zpdefault-section zpdefault-section-bg" data-element-id="elm_UwiuhIpUEszshCRXyr6MkQ" data-element-type="row" data-equal-column="false">
+         <style type="text/css">
+         </style>
+         <div class="zpelem-col zpcol-12 zpcol-md-12 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg" data-element-id="elm_bBZpR4SQEEx-K6rCselwtQ" data-element-type="column">
+          <style type="text/css">
+          </style>
+          <div class="zpelement zpelem-heading" data-element-id="elm_lHLak7DwPxKNcvjx3XUOWA" data-element-type="heading">
+           <style>
+            [data-element-id="elm_lHLak7DwPxKNcvjx3XUOWA"].zpelem-heading { margin-block-start:-79px; }
+           </style>
+           <h2 class="zpheading zpheading-style-none zpheading-align-left zpheading-align-mobile-left zpheading-align-tablet-left" data-editor="true">
+            <div style="color:inherit;">
+             <h2>
+              <span style="font-size:14px;">
+               TESTIMONIALS
+              </span>
+             </h2>
+            </div>
+           </h2>
+          </div>
+          <div class="zpelement zpelem-heading" data-element-id="elm_455Ga_GbTzYXWgpe22vwfg" data-element-type="heading">
+           <style>
+           </style>
+           <h2 class="zpheading zpheading-style-none zpheading-align-left zpheading-align-mobile-left zpheading-align-tablet-left" data-editor="true">
+            <div style="color:inherit;">
+             <h2 style="font-size:32px;">
+              What our customers say
+             </h2>
+            </div>
+           </h2>
+          </div>
+         </div>
+        </div>
+       </div>
+      </div>
+      <div class="zpsection zpdefault-section zpdefault-section-bg zscustom-section-29" data-element-id="elm_SxrXAPJN3qQYFLrWgKXFFw" data-element-type="section">
+       <style type="text/css">
+        [data-element-id="elm_SxrXAPJN3qQYFLrWgKXFFw"].zpsection{ padding-block-start:9px; }
+       </style>
+       <div class="zpcontainer-fluid zpcontainer">
+        <div class="zprow zprow-container zpalign-items-flex-start zpjustify-content-flex-start" data-element-id="elm_EV4WT7UoxRptvDDwYNOVtA" data-element-type="row" data-equal-column="false">
+         <style type="text/css">
+         </style>
+         <div class="zpelem-col zpcol-12 zpcol-md-4 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg" data-element-id="elm_hOu-4P6EjQjykLhxEsYz2Q" data-element-type="column">
+          <style type="text/css">
+           [data-element-id="elm_hOu-4P6EjQjykLhxEsYz2Q"].zpelem-col{ margin-block-start:-24px; }
+          </style>
+          <div class="zpelem-box zpelement zpbox-container zsbox-container-style-02 zpdefault-section zpdefault-section-bg" data-element-id="elm_eDa7n-yHNE9xDnaeMUjMTQ" data-element-type="box">
+           <style type="text/css">
+           </style>
+           <div class="zpelement zpelem-icon" data-element-id="elm_J4bGX_vPMAtfAsQd1mQJeA" data-element-type="icon">
+            <style type="text/css">
+            </style>
+            <div class="zpicon-container zpicon-align-left zpicon-align-mobile-left zpicon-align-tablet-left">
+             <style>
+             </style>
+             <span class="zpicon zpicon-common zpicon-anchor zpicon-size-md zpicon-style-none">
+              <svg aria-label="hidden" height="512" viewbox="0 0 512 512" width="512" xmlns="http://www.w3.org/2000/svg">
+               <path d="M464 256h-80v-64c0-35.3 28.7-64 64-64h8c13.3 0 24-10.7 24-24V56c0-13.3-10.7-24-24-24h-8c-88.4 0-160 71.6-160 160v240c0 26.5 21.5 48 48 48h128c26.5 0 48-21.5 48-48V304c0-26.5-21.5-48-48-48zm-288 0H96v-64c0-35.3 28.7-64 64-64h8c13.3 0 24-10.7 24-24V56c0-13.3-10.7-24-24-24h-8C71.6 32 0 103.6 0 192v240c0 26.5 21.5 48 48 48h128c26.5 0 48-21.5 48-48V304c0-26.5-21.5-48-48-48z">
+               </path>
+              </svg>
+             </span>
+            </div>
+           </div>
+           <div class="zpelement zpelem-text" data-element-id="elm_gxTdFdGSmz2ZInojx8F3sg" data-element-type="text">
+            <style>
+            </style>
+            <div class="zptext zptext-align-left zptext-align-mobile-left zptext-align-tablet-left" data-editor="true">
+             <p>
+              <span style="color:inherit;">
+               "Needless to say we are extremely satisfied with the results. Thanks guys, keep up the good work! Your Captive Portal is great. Your solution has really helped our business."
+              </span>
+             </p>
+             <p>
+              <br/>
+             </p>
+             <p>
+              <span style="color:inherit;font-size:12px;">
+               <span style="font-weight:700;margin-bottom:8px;">
+                MARKETING MANAGER
+               </span>
+              </span>
+             </p>
+             <p>
+              <span style="color:inherit;">
+               <span style="font-weight:700;">
+                Nady Cane
+               </span>
+              </span>
+              <span style="color:inherit;">
+              </span>
+             </p>
+            </div>
+           </div>
+          </div>
+         </div>
+         <div class="zpelem-col zpcol-12 zpcol-md-4 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg" data-element-id="elm_9GUrX0lDissaVzM-iSARsw" data-element-type="column">
+          <style type="text/css">
+          </style>
+          <div class="zpelem-box zpelement zpbox-container zsbox-container-style-02 zpdefault-section zpdefault-section-bg" data-element-id="elm_DOfhOBihMeoX-fcnXRLSpQ" data-element-type="box">
+           <style type="text/css">
+            [data-element-id="elm_DOfhOBihMeoX-fcnXRLSpQ"].zpelem-box{ margin-block-start:-6px; }
+           </style>
+           <div class="zpelement zpelem-icon" data-element-id="elm_x8zd5_v1HzawBVq6Nn6dSQ" data-element-type="icon">
+            <style type="text/css">
+            </style>
+            <div class="zpicon-container zpicon-align-left zpicon-align-mobile-left zpicon-align-tablet-left">
+             <style>
+             </style>
+             <span class="zpicon zpicon-common zpicon-anchor zpicon-size-md zpicon-style-none">
+              <svg aria-label="hidden" height="512" viewbox="0 0 512 512" width="512" xmlns="http://www.w3.org/2000/svg">
+               <path d="M464 256h-80v-64c0-35.3 28.7-64 64-64h8c13.3 0 24-10.7 24-24V56c0-13.3-10.7-24-24-24h-8c-88.4 0-160 71.6-160 160v240c0 26.5 21.5 48 48 48h128c26.5 0 48-21.5 48-48V304c0-26.5-21.5-48-48-48zm-288 0H96v-64c0-35.3 28.7-64 64-64h8c13.3 0 24-10.7 24-24V56c0-13.3-10.7-24-24-24h-8C71.6 32 0 103.6 0 192v240c0 26.5 21.5 48 48 48h128c26.5 0 48-21.5 48-48V304c0-26.5-21.5-48-48-48z">
+               </path>
+              </svg>
+             </span>
+            </div>
+           </div>
+           <div class="zpelement zpelem-text" data-element-id="elm_6MvkF6O7uQAh1l9kYFrsjg" data-element-type="text">
+            <style>
+            </style>
+            <div class="zptext zptext-align-left zptext-align-mobile-left zptext-align-tablet-left" data-editor="true">
+             <div style="color:inherit;">
+              <p>
+               "I would also like to say thank you to all your staff. I love IronWiFi. Your platform was worth a fortune to my company."
+              </p>
+              <p>
+               <br/>
+              </p>
+              <p>
+               <br/>
+              </p>
+              <p>
+               <span style="font-size:12px;">
+                <span style="margin-bottom:8px;font-weight:700;">
+                 MARKETING SPECIALIST
+                </span>
+               </span>
+              </p>
+              <p>
+               <span style="font-weight:700;">
+                Joe Kaiser
+               </span>
+              </p>
+             </div>
+            </div>
+           </div>
+          </div>
+         </div>
+         <div class="zpelem-col zpcol-12 zpcol-md-4 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg" data-element-id="elm_jq5POv4c-c1SvgtcvfU0HQ" data-element-type="column">
+          <style type="text/css">
+          </style>
+          <div class="zpelem-box zpelement zpbox-container zsbox-container-style-02 zpdefault-section zpdefault-section-bg" data-element-id="elm_thAEYrphfeg_PH9teCpkPw" data-element-type="box">
+           <style type="text/css">
+            [data-element-id="elm_thAEYrphfeg_PH9teCpkPw"].zpelem-box{ margin-block-start:-5px; }
+           </style>
+           <div class="zpelement zpelem-icon" data-element-id="elm_U2Yp_ENPhHcV-XHKk2WLEw" data-element-type="icon">
+            <style type="text/css">
+            </style>
+            <div class="zpicon-container zpicon-align-left zpicon-align-mobile-left zpicon-align-tablet-left">
+             <style>
+             </style>
+             <span class="zpicon zpicon-common zpicon-anchor zpicon-size-md zpicon-style-none">
+              <svg aria-label="hidden" height="512" viewbox="0 0 512 512" width="512" xmlns="http://www.w3.org/2000/svg">
+               <path d="M464 256h-80v-64c0-35.3 28.7-64 64-64h8c13.3 0 24-10.7 24-24V56c0-13.3-10.7-24-24-24h-8c-88.4 0-160 71.6-160 160v240c0 26.5 21.5 48 48 48h128c26.5 0 48-21.5 48-48V304c0-26.5-21.5-48-48-48zm-288 0H96v-64c0-35.3 28.7-64 64-64h8c13.3 0 24-10.7 24-24V56c0-13.3-10.7-24-24-24h-8C71.6 32 0 103.6 0 192v240c0 26.5 21.5 48 48 48h128c26.5 0 48-21.5 48-48V304c0-26.5-21.5-48-48-48z">
+               </path>
+              </svg>
+             </span>
+            </div>
+           </div>
+           <div class="zpelement zpelem-text" data-element-id="elm_331WRuA7n_u0PXEVfzYZ8A" data-element-type="text">
+            <style>
+            </style>
+            <div class="zptext zptext-align-left zptext-align-mobile-left zptext-align-tablet-left" data-editor="true">
+             <p>
+              <span style="color:inherit;">
+               "We are always looking for ways to improve our customers' experiences, and this new service will help us achieve that goal."
+              </span>
+             </p>
+             <p>
+              <span style="color:inherit;">
+               <br/>
+              </span>
+             </p>
+             <p>
+              <span style="color:inherit;">
+               <br/>
+              </span>
+             </p>
+             <p>
+              <span style="color:inherit;font-size:12px;">
+               <span style="font-weight:700;margin-bottom:8px;">
+                HOTEL MANAGER
+               </span>
+              </span>
+             </p>
+             <p>
+              <span style="color:inherit;">
+               <span style="font-weight:700;">
+                Anna Brown
+               </span>
+              </span>
+             </p>
+            </div>
+           </div>
+          </div>
+         </div>
+        </div>
+       </div>
+      </div>
+      <div class="zpsection zplight-section zplight-section-bg zscustom-section-178" data-element-id="elm_vdftGwRissyZ7wlf5e-6mQ" data-element-type="section" style="background-color:rgba(161, 196, 232, 0.26);background-image:unset;">
+       <style type="text/css">
+        [data-element-id="elm_vdftGwRissyZ7wlf5e-6mQ"].zpsection{ padding-block-start:1px; padding-block-end:1px; }
+       </style>
+       <div class="zpcontainer-fluid zpcontainer">
+        <div class="zprow zprow-container zpalign-items-flex-start zpjustify-content-center" data-element-id="elm_KENNAwQAmolYSSqUbnFikQ" data-element-type="row" data-equal-column="">
+         <style type="text/css">
+         </style>
+         <div class="zpelem-col zpcol-12 zpcol-md-12 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg" data-element-id="elm_Fk4szMCkeIgnGUjGo_kXAw" data-element-type="column">
+          <style type="text/css">
+          </style>
+          <div class="zpelement zpelem-heading" data-element-id="elm_2TQa7AqYsB_9XeUNQMkFng" data-element-type="heading">
+           <style>
+           </style>
+           <h2 class="zpheading zpheading-style-none zpheading-align-left zpheading-align-mobile-left zpheading-align-tablet-left" data-editor="true">
+            <div style="color:inherit;">
+             <h2 style="font-size:30px;">
+              3 Steps to Starting IronWiFi
+             </h2>
+            </div>
+           </h2>
+          </div>
+         </div>
+         <div class="zpelem-col zpcol-12 zpcol-md-12 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg" data-element-id="elm_Ni9_1sDZkSGFrFGggjKlGw" data-element-type="column">
+          <style type="text/css">
+          </style>
+          <div class="zpelement zpelem-text zsmobile-align-center" data-element-id="elm_WWz2X_xMOkfHaFqkw0ZjOw" data-element-type="text">
+           <style>
+           </style>
+           <div class="zptext zptext-align-left zptext-align-mobile-left zptext-align-tablet-left" data-editor="true">
+            <div style="color:inherit;">
+             <div>
+              <h4 style="font-size:18px;">
+               <span style="font-weight:700;">
+                01  Set up an IronWiFi account
+               </span>
+              </h4>
+             </div>
+             <p>
+              Simply provide a few basic details: name, email, phone, and password.
+             </p>
+             <p>
+              <br/>
+             </p>
+             <div>
+              <h4 style="font-size:18px;">
+               <span style="font-weight:700;">
+                02  Configure your Wireless Access Points
+               </span>
+              </h4>
+             </div>
+             <p>
+              Configure IronWiFi's authentication service.
+             </p>
+             <p>
+              <br/>
+             </p>
+             <div>
+              <h4 style="font-size:18px;">
+               <span style="font-weight:700;">
+                03  Set up monitoring and reporting
+               </span>
+              </h4>
+             </div>
+             <p>
+              IronWiFi will start processing your requests while you explore the app’s features.
+             </p>
+            </div>
+           </div>
+          </div>
+         </div>
+         <div class="zpelem-col zpcol-12 zpcol-md-8 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg" data-element-id="elm_4cEsbnuo8X9RI85vLYew0A" data-element-type="column">
+          <style type="text/css">
+          </style>
+          <div class="zprow zprow-container zpalign-items-flex-start zpjustify-content-flex-start" data-element-id="elm_NmG_ElNMSwIRcPCrUEdGtA" data-element-type="row" data-equal-column="">
+           <style type="text/css">
+           </style>
+           <div class="zpelem-col zpcol-12 zpcol-md-12 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg" data-element-id="elm_sBHMldZWh1uvoFs7sMcwVw" data-element-type="column">
+            <style type="text/css">
+            </style>
+            <div class="zpelement zpelem-spacer" data-element-id="elm_LsDXf0vz2McbjcH3-J32kw" data-element-type="spacer">
+             <style>
+              div[data-element-id="elm_LsDXf0vz2McbjcH3-J32kw"] div.zpspacer { height:0px; } @media (max-width: 768px) { div[data-element-id="elm_LsDXf0vz2McbjcH3-J32kw"] div.zpspacer { height:calc(0px / 3); } }
+             </style>
+             <div class="zpspacer" data-height="0">
+             </div>
+            </div>
+           </div>
+          </div>
+          <div class="zprow zprow-container zpalign-items-flex-start zpjustify-content-flex-start" data-element-id="elm_HMur-kFjkFTJvxt_oI0qHg" data-element-type="row" data-equal-column="">
+           <style type="text/css">
+           </style>
+           <div class="zpelem-col zpcol-12 zpcol-md-12 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg" data-element-id="elm_nyLJMjLIrOO2nCAkAdbOEA" data-element-type="column">
+            <style type="text/css">
+            </style>
+            <div class="zpelement zpelem-spacer" data-element-id="elm_FunE6D_MB4tz2nP2sGfFDg" data-element-type="spacer">
+             <style>
+              div[data-element-id="elm_FunE6D_MB4tz2nP2sGfFDg"] div.zpspacer { height:30px; } @media (max-width: 768px) { div[data-element-id="elm_FunE6D_MB4tz2nP2sGfFDg"] div.zpspacer { height:calc(30px / 3); } }
+             </style>
+             <div class="zpspacer" data-height="30">
+             </div>
+            </div>
+           </div>
+          </div>
+         </div>
+        </div>
+       </div>
+      </div>
+     </div>
+    </div>
+   </div>
+  </div>
+  <div style="clear:both;">
+  </div>
+  <div class="theme-footer-area zpdark-section zpdark-section-bg theme-pages-full-stretch" role="contentinfo">
+   <div data-footer-type="site_footer">
+    <div class="zpcontent-container footer-container">
+     <div class="zpsection zpdefault-section zpdefault-section-bg" data-element-id="elm_YeB85FftQm6R6T-8K8a8Aw" data-element-type="section">
+      <style type="text/css">
+       [data-element-id="elm_YeB85FftQm6R6T-8K8a8Aw"].zpsection{ border-radius:1px; }
+      </style>
+      <div class="zpcontainer-fluid zpcontainer">
+       <div class="zprow zprow-container zpalign-items-center zpjustify-content-flex-start zpdefault-section zpdefault-section-bg" data-element-id="elm_FAKGXANeRKSRfWxlZ72THA" data-element-type="row" data-equal-column="false">
+        <style type="text/css">
+         [data-element-id="elm_FAKGXANeRKSRfWxlZ72THA"].zprow{ border-radius:1px; }
+        </style>
+        <div class="zpelem-col zpcol-12 zpcol-md-4 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg" data-element-id="elm_KVIG1N7BQmaQddL86ydqNA" data-element-type="column">
+         <style type="text/css">
+          [data-element-id="elm_KVIG1N7BQmaQddL86ydqNA"].zpelem-col{ border-radius:1px; }
+         </style>
+         <div class="zpelement zpelem-text" data-element-id="elm_x8KYFBT3gnxVOdMAbxQ-lw" data-element-type="text">
+          <style>
+          </style>
+          <div class="zptext zptext-align-left zptext-align-mobile-left zptext-align-tablet-left" data-editor="true">
+           <p>
+            <span style="font-size:13px;">
+             Sales:
+             <a href="mailto:sales@ironwifi.com">
+              sales@ironwifi.com
+             </a>
+            </span>
+           </p>
+           <div>
+            <p>
+             <span style="font-size:13px;">
+              Technical:
+              <a href="mailto:support@ironwifi.com">
+               support@ironwifi.com
+              </a>
+             </span>
+            </p>
+            <p style="line-height:2;">
+             <span style="font-size:13px;">
+              Emergency phone number:
+             </span>
+             <span style="font-size:13px;">
+              +1 (800) 963-6221
+             </span>
+            </p>
+           </div>
+          </div>
+         </div>
+        </div>
+        <div class="zpelem-col zpcol-12 zpcol-md-4 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg" data-element-id="elm_mBQBQqgDThmZCL6i-VjeCA" data-element-type="column">
+         <style type="text/css">
+          [data-element-id="elm_mBQBQqgDThmZCL6i-VjeCA"].zpelem-col{ border-radius:1px; }
+         </style>
+         <div class="zpapp" data-align="left" data-app-type="menu_app" data-element-id="elm_ZQjLQ8RQyVxH8rVt1EssmA" data-element-type="app" data-heading_toggle="false" data-hide_submenu_toggle="true" data-horizontal_style="none" data-menu_label="Quick Links" data-tag="h4" data-type="horizontal" data-vertical_style="none" data-zs-app="menu_app">
+          <div class="app-container">
+          </div>
+         </div>
+        </div>
+        <div class="zpelem-col zpcol-12 zpcol-md-4 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg" data-element-id="elm_9GY_56c9S_u8sCsLgzgOjg" data-element-type="column">
+         <style type="text/css">
+          [data-element-id="elm_9GY_56c9S_u8sCsLgzgOjg"].zpelem-col{ border-radius:1px; }
+         </style>
+         <div class="zpelement zpelem-socialprofile" data-animation-name="fadeInUp" data-element-id="elm_ObM-ur4_T3qedOgP1qYOJw" data-element-type="socialprofile" itemscope="">
+          <style type="text/css">
+           [data-element-id="elm_ObM-ur4_T3qedOgP1qYOJw"].zpelem-socialprofile{ border-radius:1px; }
+          </style>
+          <div class="zpsocialprofile-container zpsocialprofile-size-md zpsocialprofile-halign-center zpsocialprofile-align-mobile-center zpsocialprofile-align-tablet-center zpsocialprofile-style-none zpsocialprofile-type-white" data-socialprofile_container="">
+           <a aria-label="LinkedIn" class="zpsocialprofile-wrapper zpsocialprofile-linkedin" href="https://www.linkedin.com/company/ironwifi/" target="_blank">
+            <svg aria-hidden="true" class="zpsocialprofile" viewbox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+             <path d="M64 4.706v54.588A4.706 4.706 0 0 1 59.294 64H4.706A4.706 4.706 0 0 1 0 59.294V4.706A4.706 4.706 0 0 1 4.706 0h54.588A4.706 4.706 0 0 1 64 4.706zM18.824 24.47H9.412v30.117h9.412V24.471zm.847-10.353a5.421 5.421 0 0 0-5.384-5.46h-.17a5.459 5.459 0 0 0 0 10.918 5.421 5.421 0 0 0 5.554-5.289v-.17zm34.917 22.174c0-9.054-5.76-12.574-11.482-12.574a10.73 10.73 0 0 0-9.525 4.856h-.263v-4.103H24.47v30.117h9.411V38.57a6.25 6.25 0 0 1 5.647-6.738h.358c2.993 0 5.214 1.882 5.214 6.625v16.132h9.412l.075-18.296z">
+             </path>
+            </svg>
+           </a>
+          </div>
+         </div>
+        </div>
+       </div>
+       <div class="zprow zprow-container zpalign-items-flex-start zpjustify-content-flex-start zpdefault-section zpdefault-section-bg" data-element-id="elm_z43UtPRvTaOaG58G1bpkgA" data-element-type="row" data-equal-column="">
+        <style type="text/css">
+         [data-element-id="elm_z43UtPRvTaOaG58G1bpkgA"].zprow{ border-radius:1px; }
+        </style>
+        <div class="zpelem-col zpcol-12 zpcol-md-12 zpcol-sm-12 zpalign-self- zpdefault-section zpdefault-section-bg" data-element-id="elm_QETQbjDLTbu2SwOzEQTaOQ" data-element-type="column">
+         <style type="text/css">
+          [data-element-id="elm_QETQbjDLTbu2SwOzEQTaOQ"].zpelem-col{ border-radius:1px; }
+         </style>
+         <div class="zpelement zpelem-spacer" data-element-id="elm_m4BUuVRFSRWVgmJ2JaxfIA" data-element-type="spacer">
+          <style>
+           div[data-element-id="elm_m4BUuVRFSRWVgmJ2JaxfIA"] div.zpspacer { height:1px; } @media (max-width: 768px) { div[data-element-id="elm_m4BUuVRFSRWVgmJ2JaxfIA"] div.zpspacer { height:calc(1px / 3); } }
+          </style>
+          <div class="zpspacer" data-height="1">
+          </div>
+         </div>
+        </div>
+       </div>
+      </div>
+     </div>
+    </div>
+   </div>
+  </div>
+  <div class="zpmm-backdrop zpmm-backdrop-enabled">
+  </div>
+ </body>
+</html>


### PR DESCRIPTION
## Summary
- unminify wpa-enterprise page for readability
- fix `IronWifi` capitalization
- remove repeated introductory paragraph
- add alt text for wireless AP images

## Testing
- `python3 -m pip install bs4 --quiet`


------
https://chatgpt.com/codex/tasks/task_b_684ac7f726908323af3ceea4742fce19